### PR TITLE
Switch to cloud logging only for deploy

### DIFF
--- a/cloudbuild/deploy/cloudbuild.yaml
+++ b/cloudbuild/deploy/cloudbuild.yaml
@@ -5,10 +5,11 @@ steps:
     args:
       - -c
       - "./cloudbuild/deploy/$TRIGGER_NAME.sh"
-    timeout: "1600s"
+    timeout: "1800s"
     secretEnv: ["VSCE_PAT", "GA_API_SECRET", "GA_MEASUREMENT_ID"]
-logsBucket: "gs://malloy-cloudbuild-logs"
-timeout: "1600s"
+options:
+  logging: CLOUD_LOGGING_ONLY
+timeout: "1800s"
 availableSecrets:
   secretManager:
     - versionName: projects/malloy-303216/secrets/marketplace-prerelease-CI/versions/latest


### PR DESCRIPTION
Logging to a bucket was failing and causing the build to appear to fail. We don't have a use for the logs that were being uploaded, so just keep using cloud logging.