### PR TITLE
Enable copy path

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,8 +108,7 @@
       {
         "command": "malloy.copyFieldPath",
         "title": "Copy Field Path",
-        "category": "Malloy",
-        "enablement": "false"
+        "category": "Malloy"
       },
       {
         "command": "malloy.refreshSchema",


### PR DESCRIPTION
Fixes https://github.com/malloydata/malloy-vscode-extension/issues/9

A lot of these commands are explicitly disabled, something changed where VSCode started applying disabled to this command in the tree view. Since the schema tree view is the only place it's used, I _think_ it's safe to just enable it?