### PR TITLE
Quick fix for npm run malloy-link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@malloydata/render": "0.0.9",
         "@observablehq/plot": "^0.1.0",
         "@vscode/webview-ui-toolkit": "^1.0.0",
+        "duckdb": "^0.5.1",
         "keytar": "7.7.0",
         "react": "^17.0.2",
         "react-is": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -338,6 +338,7 @@
     "@malloydata/render": "0.0.9",
     "@observablehq/plot": "^0.1.0",
     "@vscode/webview-ui-toolkit": "^1.0.0",
+    "duckdb": "^0.5.1",
     "keytar": "7.7.0",
     "react": "^17.0.2",
     "react-is": "^16.8.0",

--- a/scripts/build-extension.ts
+++ b/scripts/build-extension.ts
@@ -192,11 +192,15 @@ export async function doBuild(target?: Target): Promise<void> {
   if (fs.existsSync(fullLicenseFilePath)) {
     fs.rmSync(fullLicenseFilePath);
   }
-  generateDisclaimer(
-    path.join(__dirname, "..", "package.json"),
-    path.join(__dirname, "..", "node_modules"),
-    fullLicenseFilePath
-  );
+  if (!development) {
+    generateDisclaimer(
+      path.join(__dirname, "..", "package.json"),
+      path.join(__dirname, "..", "node_modules"),
+      fullLicenseFilePath
+    );
+  } else {
+    fs.writeFileSync(fullLicenseFilePath, "LICENSES GO HERE\n");
+  }
 
   fs.writeFileSync(
     path.join(outDir, "build-sha"),


### PR DESCRIPTION
Don't try and generate license file when in dev mode because not all packages may be in node_modules, create dependency on duckdb because we pull out duckdb.node during build.