### PR TITLE
Harden build script to support linking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@malloydata/malloy": "0.0.14",
         "@malloydata/render": "0.0.14",
         "@observablehq/plot": "^0.1.0",
-        "@types/lodash": "^4.14.191",
         "@vscode/webview-ui-toolkit": "^1.0.0",
         "duckdb": "0.6.1",
         "keytar": "7.7.0",
@@ -27,8 +26,7 @@
         "styled-components": "^5.3.3",
         "vscode-languageclient": "^7.0.0",
         "vscode-languageserver": "^7.0.0",
-        "vscode-languageserver-textdocument": "^1.0.1",
-        "yargs": "~17.6.0"
+        "vscode-languageserver-textdocument": "^1.0.1"
       },
       "devDependencies": {
         "@jest/globals": "^26.6.2",
@@ -36,6 +34,7 @@
         "@types/jest": "^29.2.1",
         "@types/jest-expect-message": "^1.0.3",
         "@types/jsdom": "^16.2.11",
+        "@types/lodash": "^4.14.191",
         "@types/node-fetch": "^3.0.3",
         "@types/prismjs": "^1.26.0",
         "@types/react": "^17.0.38",
@@ -2456,7 +2455,8 @@
     "node_modules/@types/lodash": {
       "version": "4.14.191",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -17114,7 +17114,8 @@
     "@types/lodash": {
       "version": "4.14.191",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
-      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -348,8 +348,7 @@
     "styled-components": "^5.3.3",
     "vscode-languageclient": "^7.0.0",
     "vscode-languageserver": "^7.0.0",
-    "vscode-languageserver-textdocument": "^1.0.1",
-    "yargs": "~17.6.0"
+    "vscode-languageserver-textdocument": "^1.0.1"
   },
   "dependenciesComments": {
     "esbuild": "READ THIS! esbuild is pinned to 0.14.13 because some version after that introduces 'use strict' to bundled js files. Consider this before upgrading"

--- a/scripts/license_disclaimer.ts
+++ b/scripts/license_disclaimer.ts
@@ -59,57 +59,63 @@ function doDependencies(nodeModulesPath: string, packageJson: any): void {
       // look for notice & license text
       let notice: string | undefined = undefined;
       let license: string | undefined = undefined;
-      const packageFiles = fs.readdirSync(
-        path.join(nodeModulesPath, dependency)
-      );
-      packageFiles.find((fileName) => {
-        const base = fileName.split(".")[0].toLowerCase();
-
-        if (base == "notice" || base == "notices") {
-          notice = fs.readFileSync(
-            path.join(nodeModulesPath, dependency, fileName),
-            "utf-8"
-          );
-        }
-
-        if (base == "license" || base == "licenses") {
-          license = fs.readFileSync(
-            path.join(nodeModulesPath, dependency, fileName),
-            "utf-8"
-          );
-        }
-      });
-
-      if (license == undefined && pkg.license == undefined) {
-        throw new Error(
-          `${dependency}: license type undefined in package.json and license file cannot be found`
+      try {
+        const packageFiles = fs.readdirSync(
+          path.join(nodeModulesPath, dependency)
         );
+        packageFiles.find((fileName) => {
+          const base = fileName.split(".")[0].toLowerCase();
+
+          if (base == "notice" || base == "notices") {
+            notice = fs.readFileSync(
+              path.join(nodeModulesPath, dependency, fileName),
+              "utf-8"
+            );
+          }
+
+          if (base == "license" || base == "licenses") {
+            license = fs.readFileSync(
+              path.join(nodeModulesPath, dependency, fileName),
+              "utf-8"
+            );
+          }
+        });
+
+        if (license == undefined && pkg.license == undefined) {
+          throw new Error(
+            `${dependency}: license type undefined in package.json and license file cannot be found`
+          );
+        }
+
+        const licenseType = pkg.license
+          ? pkg.license
+          : "see license text below";
+
+        const url = [
+          pkg.homepage,
+          pkg.repository?.url,
+          pkg.repository?.baseUrl,
+          pkg.repo,
+          `https://npmjs.com/package/${dependency}`,
+        ].find((el) => el !== undefined);
+
+        fs.appendFileSync(
+          filePath,
+          `
+  -------
+  Package: ${dependency}
+  Url: ${url}
+  License(s): ${licenseType}
+  ${license ? "License Text:\n" + license + "\n" : ""}
+  ${notice ? "\nNotice:\n" + notice + "\n" : ""}
+          `
+        );
+
+        seen[dependency] = true;
+        doDependencies(nodeModulesPath, pkg);
+      } catch (error) {
+        console.warn("Could not read package.json", error.message);
       }
-
-      const licenseType = pkg.license ? pkg.license : "see license text below";
-
-      const url = [
-        pkg.homepage,
-        pkg.repository?.url,
-        pkg.repository?.baseUrl,
-        pkg.repo,
-        `https://npmjs.com/package/${dependency}`,
-      ].find((el) => el !== undefined);
-
-      fs.appendFileSync(
-        filePath,
-        `
--------
-Package: ${dependency}
-Url: ${url}
-License(s): ${licenseType}
-${license ? "License Text:\n" + license + "\n" : ""}
-${notice ? "\nNotice:\n" + notice + "\n" : ""}
-        `
-      );
-
-      seen[dependency] = true;
-      doDependencies(nodeModulesPath, pkg);
     }
   }
 }

--- a/scripts/utils/licenses.ts
+++ b/scripts/utils/licenses.ts
@@ -11,24 +11,31 @@
  * GNU General Public License for more details.
  */
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable no-console */
 import fs from "fs";
 
-export function readPackageJson(path: string): any {
+export interface NpmPackage {
+  dependencies?: Record<string, string>;
+  homepage?: string;
+  license?: string;
+  repo?: string;
+  repository?: {
+    baseUrl?: string;
+    url?: string;
+  };
+}
+
+export function readPackageJson(path: string): NpmPackage {
   try {
     const fileBuffer = fs.readFileSync(path, "utf8");
     return JSON.parse(fileBuffer);
   } catch (error) {
-    console.error("Could not read package.json", error);
-    throw error;
+    console.warn("Could not read package.json", error.message);
   }
+  return {};
 }
 
 export function getDependencies(rootPackageJson: string): string[] {
   const rootPackage = readPackageJson(rootPackageJson);
-  // eslint-disable-next-line no-prototype-builtins
-  return rootPackage.hasOwnProperty("dependencies")
-    ? Object.keys(rootPackage.dependencies)
-    : [];
+  return Object.keys(rootPackage.dependencies || {}) || [];
 }


### PR DESCRIPTION
When linking, packages from linked dependencies aren't hoisted, so the license builder needs to be hardened against this. 