### PR TITLE
Fix typo in "end" match rule for query-in-sql

### DIFF
--- a/malloy.tmGrammar.json
+++ b/malloy.tmGrammar.json
@@ -19,7 +19,7 @@
     "query-in-sql": {
       "begin": "%{",
       "name": "source.internal-query-stuff",
-      "end": "%}",
+      "end": "}%",
       "patterns": [
         { "include": "#sql-string" },
         { "include": "#comments" },


### PR DESCRIPTION
VSCode formatting is breaking with the SQL Turducken. Looks like this is caused by a typo in the textmate grammar.

Before:
![image](https://user-images.githubusercontent.com/79773/209058834-0c86a022-d701-49ed-a027-3140d53e62e1.png)

After:
![image](https://user-images.githubusercontent.com/79773/209058861-fc443daf-2e27-48bb-b8cc-27c9d2ab4597.png)
