### PR TITLE
Ignore more files when packaging

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,4 +5,8 @@ src/
 tsconfig.json
 tsconfig.tsbuildinfo
 esbuild.config.ts
+jest.config.js
 package.json.original
+third_party/
+scripts/
+test/


### PR DESCRIPTION
I failed to update .vscodeignore when the directory structure changed. This should slim down our package.