### PR TITLE
Urls all the way down

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,12 +187,6 @@
     "views": {
       "explorer": [
         {
-          "id": "malloyHelp",
-          "name": "Malloy Help",
-          "type": "webview",
-          "when": "malloy.webviewPanelFocused == true || resourceFilename =~ /\\.malloy$/"
-        },
-        {
           "id": "malloySchema",
           "name": "Malloy Schema",
           "when": "malloy.webviewPanelFocused == true || resourceFilename =~ /\\.malloy$/"
@@ -288,6 +282,48 @@
                     "type": "string"
                   },
                   "serviceAccountKeyPath": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "backend": {
+                    "type": "string",
+                    "const": "duckdb"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "isDefault": {
+                    "type": "boolean"
+                  },
+                  "workingDirectory": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "backend": {
+                    "type": "string",
+                    "const": "duckdb_wasm"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "isDefault": {
+                    "type": "boolean"
+                  },
+                  "workingDirectory": {
                     "type": "string"
                   }
                 }

--- a/src/common/connection_manager_types.ts
+++ b/src/common/connection_manager_types.ts
@@ -28,6 +28,11 @@ export enum ConnectionBackend {
   DuckDBWASM = "duckdb_wasm",
 }
 
+/*
+ * NOTE: These should be kept in sync with the "malloy.connections"
+ * section of the extension "configuration" definition in package.json
+ */
+
 export interface BigQueryConnectionConfig {
   backend: ConnectionBackend.BigQuery;
   name: string;
@@ -60,6 +65,7 @@ export interface DuckDBConnectionConfig {
   id: string;
   workingDirectory?: string;
 }
+
 export interface DuckDBWASMConnectionConfig {
   backend: ConnectionBackend.DuckDBWASM;
   name: string;

--- a/src/extension/browser/extension_browser.ts
+++ b/src/extension/browser/extension_browser.ts
@@ -79,7 +79,7 @@ export async function deactivate(): Promise<void> | undefined {
 }
 
 function setupLanguageServer(context: vscode.ExtensionContext): void {
-  const documentSelector = [{ scheme: "file", language: "malloy" }];
+  const documentSelector = [{ language: "malloy" }];
 
   // Options to control the language client
   const clientOptions: LanguageClientOptions = {

--- a/src/extension/commands/query_download.ts
+++ b/src/extension/commands/query_download.ts
@@ -61,7 +61,7 @@ const sendDownloadMessage = (
   query: WorkerQuerySpec,
   panelId: string,
   name: string,
-  filePath: string,
+  uri: string,
   downloadOptions: QueryDownloadOptions
 ) => {
   const worker = getWorker();
@@ -70,7 +70,7 @@ const sendDownloadMessage = (
     query,
     panelId,
     name,
-    filePath,
+    uri,
     downloadOptions,
   };
   worker.send?.(message);
@@ -136,10 +136,9 @@ export async function queryDownload(
         } else {
           const worker = getWorker();
           const { file, ...params } = query;
-          const fsPath = file.uri.fsPath;
           sendDownloadMessage(
             {
-              file: fsPath,
+              uri: file.uri.toString(),
               ...params,
             },
             panelId,

--- a/src/extension/commands/run_query_utils.ts
+++ b/src/extension/commands/run_query_utils.ts
@@ -179,12 +179,12 @@ export function runMalloyQuery(
       });
 
       const { file, ...params } = query;
-      const fsPath = file.uri.fsPath;
+      const uri = file.uri.toString();
       const worker = getWorker();
       worker.send({
         type: "run",
         query: {
-          file: fsPath,
+          uri,
           ...params,
         },
         panelId,

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -24,17 +24,17 @@
 import { URLReader } from "@malloydata/malloy";
 import * as vscode from "vscode";
 
-export async function fetchFile(path: string): Promise<string> {
+export async function fetchFile(uri: string): Promise<string> {
   const openFiles = vscode.workspace.textDocuments;
   const openDocument = openFiles.find(
-    (document) => document.uri.fsPath === path
+    (document) => document.uri.toString() === uri
   );
   // Only get the text from VSCode's open files if the file is already open in VSCode,
   // otherwise, just read the file from the file system
   if (openDocument !== undefined) {
     return openDocument.getText();
   } else {
-    const contents = await vscode.workspace.fs.readFile(vscode.Uri.file(path));
+    const contents = await vscode.workspace.fs.readFile(vscode.Uri.parse(uri));
     return new TextDecoder("utf-8").decode(contents);
   }
 }

--- a/src/worker/browser/files.ts
+++ b/src/worker/browser/files.ts
@@ -63,7 +63,6 @@ export async function fetchFile(uri: string): Promise<string> {
 
 export class WorkerURLReader implements URLReader {
   async readURL(url: URL): Promise<string> {
-    // TODO(web) Fix possibly encoded pathname
     return fetchFile(url.toString());
   }
 }

--- a/src/worker/browser/files.ts
+++ b/src/worker/browser/files.ts
@@ -35,12 +35,12 @@ let idx = 1;
  * @param file File path to resolve
  * @returns File contents
  */
-export async function fetchFile(file: string): Promise<string> {
+export async function fetchFile(uri: string): Promise<string> {
   return new Promise((resolve, reject) => {
     // This could probably use some more error handling (timeout?).
     // For now just be relentlessly optimistic because there's
     // a tight coupling with the worker controller.
-    const id = `${file}-${idx++}`;
+    const id = `${uri}-${idx++}`;
     const callback = (event: MessageEvent) => {
       const message: Message = event.data;
       if (message.type === "read" && message.id === id) {
@@ -55,7 +55,7 @@ export async function fetchFile(file: string): Promise<string> {
     self.addEventListener("message", callback);
     self.postMessage({
       type: "read",
-      file,
+      uri,
       id,
     });
   });
@@ -64,6 +64,6 @@ export async function fetchFile(file: string): Promise<string> {
 export class WorkerURLReader implements URLReader {
   async readURL(url: URL): Promise<string> {
     // TODO(web) Fix possibly encoded pathname
-    return fetchFile(url.pathname);
+    return fetchFile(url.toString());
   }
 }

--- a/src/worker/browser/worker_connection.ts
+++ b/src/worker/browser/worker_connection.ts
@@ -63,7 +63,7 @@ export class WorkerConnection {
             workerLog.appendLine(`worker: ${message.message}`);
             break;
           case "read": {
-            workerLog.appendLine(`worker: reading file ${message.file}`);
+            workerLog.appendLine(`worker: reading file ${message.url}`);
             this.readFile(message);
             break;
           }

--- a/src/worker/browser/worker_connection.ts
+++ b/src/worker/browser/worker_connection.ts
@@ -63,7 +63,7 @@ export class WorkerConnection {
             workerLog.appendLine(`worker: ${message.message}`);
             break;
           case "read": {
-            workerLog.appendLine(`worker: reading file ${message.url}`);
+            workerLog.appendLine(`worker: reading file ${message.uri}`);
             this.readFile(message);
             break;
           }

--- a/src/worker/browser/worker_connection.ts
+++ b/src/worker/browser/worker_connection.ts
@@ -108,12 +108,12 @@ export class WorkerConnection {
   }
 
   async readFile(message: WorkerReadMessage): Promise<void> {
-    const { id, file } = message;
+    const { id, uri } = message;
     try {
-      const data = await fetchFile(file);
-      this.send({ type: "read", id, file, data });
+      const data = await fetchFile(uri);
+      this.send({ type: "read", id, uri, data });
     } catch (error) {
-      this.send({ type: "read", id, file, error: error.message });
+      this.send({ type: "read", id, uri, error: error.message });
     }
   }
 }

--- a/src/worker/download_query.ts
+++ b/src/worker/download_query.ts
@@ -22,6 +22,7 @@
  */
 
 import * as fs from "fs";
+import { fileURLToPath } from "url";
 
 import { CSVWriter, JSONWriter, Runtime } from "@malloydata/malloy";
 
@@ -41,7 +42,7 @@ const sendMessage = (name: string, error?: string) => {
 
 export async function downloadQuery(
   connectionManager: ConnectionManager,
-  { query, panelId, downloadOptions, name, filePath }: MessageDownload
+  { query, panelId, downloadOptions, name, uri }: MessageDownload
 ): Promise<void> {
   const files = new WorkerURLReader();
   const url = new URL(panelId);
@@ -53,7 +54,7 @@ export async function downloadQuery(
     );
 
     const runnable = createRunnable(query, runtime);
-    const writeStream = fs.createWriteStream(filePath);
+    const writeStream = fs.createWriteStream(fileURLToPath(uri));
     const writer =
       downloadOptions.format === "json"
         ? new JSONWriter(writeStream)

--- a/src/worker/node/download_query.ts
+++ b/src/worker/node/download_query.ts
@@ -26,10 +26,10 @@ import { fileURLToPath } from "url";
 
 import { CSVWriter, JSONWriter, Runtime } from "@malloydata/malloy";
 
-import { MessageDownload, WorkerDownloadMessage } from "./types";
-import { createRunnable } from "./utils";
-import { WorkerURLReader } from "./node/files";
-import { ConnectionManager } from "../common/connection_manager";
+import { MessageDownload, WorkerDownloadMessage } from "../types";
+import { createRunnable } from "../utils";
+import { WorkerURLReader } from "./files";
+import { ConnectionManager } from "../../common/connection_manager";
 
 const sendMessage = (name: string, error?: string) => {
   const msg: WorkerDownloadMessage = {

--- a/src/worker/node/files.ts
+++ b/src/worker/node/files.ts
@@ -36,12 +36,12 @@ let idx = 1;
  * @param file File path to resolve
  * @returns File contents
  */
-export async function fetchFile(file: string): Promise<string> {
+export async function fetchFile(uri: string): Promise<string> {
   return new Promise((resolve, reject) => {
     // This could probably use some more error handling (timeout?).
     // For now just be relentlessly optimistic because there's
     // a tight coupling with the worker controller.
-    const id = `${file}-${idx++}`;
+    const id = `${uri}-${idx++}`;
     const callback = (message: Message) => {
       if (message.type === "read" && message.id === id) {
         if (message.data != null) {
@@ -55,7 +55,7 @@ export async function fetchFile(file: string): Promise<string> {
     process.on("message", callback);
     process.send?.({
       type: "read",
-      file,
+      uri,
       id,
     });
   });
@@ -63,6 +63,6 @@ export async function fetchFile(file: string): Promise<string> {
 
 export class WorkerURLReader implements URLReader {
   async readURL(url: URL): Promise<string> {
-    return fetchFile(fileURLToPath(url));
+    return fetchFile(url.toString());
   }
 }

--- a/src/worker/node/files.ts
+++ b/src/worker/node/files.ts
@@ -23,7 +23,6 @@
 
 import { URLReader } from "@malloydata/malloy";
 import { Message } from "../types";
-import { fileURLToPath } from "url";
 
 let idx = 1;
 

--- a/src/worker/node/message_handler.ts
+++ b/src/worker/node/message_handler.ts
@@ -23,7 +23,7 @@
 
 import { log } from "../logger";
 import { cancelQuery, runQuery } from "../run_query";
-import { downloadQuery } from "../download_query";
+import { downloadQuery } from "./download_query";
 import { Message, MessageHandler, WorkerMessage } from "../types";
 import { refreshConfig } from "../refresh_config";
 import { ConnectionManager } from "../../common/connection_manager";

--- a/src/worker/node/worker_connection.ts
+++ b/src/worker/node/worker_connection.ts
@@ -64,7 +64,7 @@ export class WorkerConnection {
               workerLog.appendLine(`worker: ${message.message}`);
               break;
             case "read": {
-              workerLog.appendLine(`worker: reading file ${message.file}`);
+              workerLog.appendLine(`worker: reading file ${message.uri}`);
               this.readFile(message);
               break;
             }
@@ -95,12 +95,12 @@ export class WorkerConnection {
   }
 
   async readFile(message: WorkerReadMessage): Promise<void> {
-    const { id, file } = message;
+    const { id, uri } = message;
     try {
-      const data = await fetchFile(file);
-      this.send?.({ type: "read", id, file, data });
+      const data = await fetchFile(uri);
+      this.send?.({ type: "read", id, uri, data });
     } catch (error) {
-      this.send?.({ type: "read", id, file, error: error.message });
+      this.send?.({ type: "read", id, uri, error: error.message });
     }
   }
 }

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -30,31 +30,31 @@ import { MalloyConfig } from "../extension/types";
 interface NamedQuerySpec {
   type: "named";
   name: string;
-  file: string;
+  uri: string;
 }
 
 interface QueryStringSpec {
   type: "string";
   text: string;
-  file: string;
+  uri: string;
 }
 
 interface QueryFileSpec {
   type: "file";
   index: number;
-  file: string;
+  uri: string;
 }
 
 interface NamedSQLQuerySpec {
   type: "named_sql";
   name: string;
-  file: string;
+  uri: string;
 }
 
 interface UnnamedSQLQuerySpec {
   type: "unnamed_sql";
   index: number;
-  file: string;
+  uri: string;
 }
 
 export type WorkerQuerySpec =
@@ -92,7 +92,7 @@ export interface MessageConfig {
 export interface MessageRead {
   type: "read";
   id: string;
-  file: string;
+  uri: string;
   data?: string;
   error?: string;
 }
@@ -102,7 +102,7 @@ export interface MessageDownload {
   query: WorkerQuerySpec;
   panelId: string;
   name: string;
-  filePath: string;
+  uri: string;
   downloadOptions: QueryDownloadOptions;
 }
 
@@ -146,7 +146,7 @@ export interface WorkerStartMessage {
 export interface WorkerReadMessage {
   type: "read";
   id: string;
-  file: string;
+  uri: string;
 }
 
 export type WorkerMessage =

--- a/src/worker/utils.ts
+++ b/src/worker/utils.ts
@@ -33,7 +33,7 @@ export const createRunnable = (
   runtime: Runtime
 ): SQLBlockMaterializer | QueryMaterializer => {
   let runnable: QueryMaterializer | SQLBlockMaterializer;
-  const queryFileURL = new URL("file://" + query.file);
+  const queryFileURL = new URL(query.uri);
   if (query.type === "string") {
     runnable = runtime.loadModel(queryFileURL).loadQuery(query.text);
   } else if (query.type === "named") {

--- a/src/worker/worker_protocol.md
+++ b/src/worker/worker_protocol.md
@@ -11,9 +11,13 @@ elements are defined per message type. Messages requiring two-way communication
 use an id parameter to match the corresponding response to the correct request.
 
 The VSCode resident part of the worker process lives in
-[worker_controller.ts](../../blob/master/src/worker/worker_controller.ts),
-the main worker file is
-[worker.ts](../../blob/master/src/worker/worker.ts)
+[worker_connection.ts](../../blob/master/src/worker/node/worker_connection.ts)
+for the node version and
+[worker_connection.ts](../../blob/master/src/worker/browser/worker_connection.ts)
+for the browser version, the main worker file is
+[worker_node.ts](../../blob/master/src/worker/node/worker_node.ts)
+for the node version and
+[worker_browser.ts](../../blob/master/src/worker/browser/worker_browser.ts).
 
 ## Example
 
@@ -25,7 +29,7 @@ A file read request from the worker to the VSCode extension:
 {
   "type": "read",
   "id": 67,
-  "file": "file:///data/flights.malloy"
+  "uri": "file:///data/flights.malloy"
 }
 ```
 
@@ -37,7 +41,7 @@ A response from VSCode to the worker containing the file contents:
 {
   "type": "read",
   "id": 67,
-  "file": "file:///data/flights.malloy",
+  "uri": "file:///data/flights.malloy",
   "data": "source: flights is table('flights.parquet') {...}"
 }
 ```
@@ -57,11 +61,11 @@ A response from VSCode to the worker containing the file contents:
   the contents of the file, either from a VS Code editor buffer or from disk.
   - Parameters:
     - `type` - "read"
-    - `file` - A file URL to return the contents for.
+    - `uri` - A URL to return the contents for.
     - `id` - ID to include in response.
   - Response:
     - `type` - "read"
-    - `file` - File URL from the request.
+    - `uri` - URL from the request.
     - `id` - ID from the request.
     - `data` - File contents or
     - `error` - Error message if an error occurred.
@@ -153,8 +157,10 @@ A message indicating that a query is now running against the database:
   to apply to the visualization.
   - `type` - "query-status";
   - `status` - "done";
-  - `result` - JSON result object
-  - `styles` - Renderer styles object
+  - `resultJson` - JSON result object
+  - `dataStyles` - Renderer styles object
+  - `canDownloadStream` - Worker can stream results to a file for unlimited
+    download
 
 ## Query Worker Spec
 
@@ -167,7 +173,7 @@ A message indicating that a query is now running against the database:
   "query": {
     "type": "named",
     "name": "flights_dashboard",
-    "file": "file:///data/flights.malloy"
+    "uri": "file:///data/flights.malloy"
   }
 }
 ```
@@ -177,23 +183,23 @@ A message indicating that a query is now running against the database:
 - **Named Query**
   - `type` - "named"
   - `name` - Name of query
-  - `file` - URL of Malloy file containing the query
+  - `uri` - URL of Malloy file containing the query
 - **Query String**
   - `type` - "string"
   - `text` - Malloy query string
-  - `file` - URL of Malloy file containing model to run query against
+  - `uri` - URL of Malloy file containing model to run query against
 - **Query File**
   - `type` - "file"
   - `index` - Index of query in the Malloy file
-  - `file` - URL of Malloy file containing the query
+  - `uri` - URL of Malloy file containing the query
 - **Named SQL Query**
   - `type` - "named_sql";
   - `name` - Name of query in the Malloy file
-  - `file` - URL of Malloy file containing the query
+  - `uri` - URL of Malloy file containing the query
 - **Unnamed SQL Query**
   - `type` - "unnamed_sql"
   - `index` - Index of query in the Malloy file
-  - `file` - URL of Malloy file containing the query
+  - `uri` - URL of Malloy file containing the query
 
 ```
 


### PR DESCRIPTION
Push any `file:` path specific code to the lowest level, deal in `uri`s wherever possible. Allow browser version to read more than file URLs. Clean up some metadata and docs. 