### PR TITLE
Use working directory in cache key

### DIFF
--- a/src/common/connection_manager.ts
+++ b/src/common/connection_manager.ts
@@ -77,6 +77,7 @@ export class ConnectionManager {
     // Force existing connections to be regenerated
     this.configList = connectionsConfig;
     this.buildConfigMap();
+    this.connectionFactory.reset();
   }
 
   public async connectionForConfig(

--- a/src/common/connections/types.ts
+++ b/src/common/connections/types.ts
@@ -29,6 +29,8 @@ import {
 import { TestableConnection } from "@malloydata/malloy";
 
 export interface ConnectionFactory {
+  reset(): void;
+
   getAvailableBackends(): ConnectionBackend[];
 
   getConnectionForConfig(


### PR DESCRIPTION
tl;dr - cache invalidation is hard.

Potential fix for https://github.com/malloydata/malloy/issues/1008, previously the first malloy file opened determined the working directory, changing working directories would not generate a new connection with a new working directory.

I would like to do away with the way working directory is currently used to create a connection, but for now it should bust the cache.