### PR TITLE
Add renderer menu to cell

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@malloydata/malloy": "0.0.27",
         "@malloydata/render": "0.0.27",
         "@popperjs/core": "^2.11.6",
-        "@types/vscode-notebook-renderer": "^1.72.0",
         "@vscode/webview-ui-toolkit": "^1.2.1",
         "duckdb": "0.7.1",
         "keytar": "7.7.0",
@@ -52,7 +51,8 @@
         "@types/styled-components": "^5.1.19",
         "@types/tar-stream": "^2.2.2",
         "@types/uuid": "^8.3.4",
-        "@types/vscode": "1.68.0",
+        "@types/vscode": "1.72.0",
+        "@types/vscode-notebook-renderer": "^1.72.0",
         "@types/vscode-webview": "^1.57.0",
         "@typescript-eslint/eslint-plugin": "^5.48.2",
         "@typescript-eslint/parser": "^5.48.2",
@@ -78,7 +78,7 @@
       },
       "engines": {
         "node": ">=12",
-        "vscode": "^1.68.0"
+        "vscode": "^1.72.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2607,15 +2607,16 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.68.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.68.0.tgz",
-      "integrity": "sha512-duBwEK5ta/eBBMJMQ7ECMEsMvlE3XJdRGh3xoS1uOO4jl2Z4LPBl5vx8WvBP10ERAgDRmIt/FaSD4RHyBGbChw==",
+      "version": "1.72.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.72.0.tgz",
+      "integrity": "sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==",
       "dev": true
     },
     "node_modules/@types/vscode-notebook-renderer": {
       "version": "1.72.0",
       "resolved": "https://registry.npmjs.org/@types/vscode-notebook-renderer/-/vscode-notebook-renderer-1.72.0.tgz",
-      "integrity": "sha512-5iTjb39DpLn03ULUwrDR3L2Dy59RV4blSUHy0oLdQuIY11PhgWO4mXIcoFS0VxY1GZQ4IcjSf3ooT2Jrrcahnw=="
+      "integrity": "sha512-5iTjb39DpLn03ULUwrDR3L2Dy59RV4blSUHy0oLdQuIY11PhgWO4mXIcoFS0VxY1GZQ4IcjSf3ooT2Jrrcahnw==",
+      "dev": true
     },
     "node_modules/@types/vscode-webview": {
       "version": "1.57.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     ]
   },
   "engines": {
-    "vscode": "^1.68.0",
+    "vscode": "^1.72.0",
     "node": ">=12"
   },
   "scripts": {
@@ -158,6 +158,66 @@
         "category": "Create",
         "command": "malloy.newUntitledNotebook",
         "title": "Malloy Notebook"
+      },
+      {
+        "title": "Table",
+        "category": "Malloy Renderer",
+        "command": "malloy.rendererTable",
+        "enablement": "notebookType == malloy-notebook && notebookCellType == code"
+      },
+      {
+        "title": "List",
+        "category": "Malloy Renderer",
+        "command": "malloy.rendererList",
+        "enablement": "notebookType == malloy-notebook && notebookCellType == code"
+      },
+      {
+        "title": "Bar Chart",
+        "category": "Malloy Renderer",
+        "command": "malloy.rendererBarChart",
+        "enablement": "notebookType == malloy-notebook && notebookCellType == code"
+      },
+      {
+        "title": "Line Chart",
+        "category": "Malloy Renderer",
+        "command": "malloy.rendererLineChart",
+        "enablement": "notebookType == malloy-notebook && notebookCellType == code"
+      },
+      {
+        "title": "Scatter Chart",
+        "category": "Malloy Renderer",
+        "command": "malloy.rendererScatterChart",
+        "enablement": "notebookType == malloy-notebook && notebookCellType == code"
+      },
+      {
+        "title": "Shape Map",
+        "category": "Malloy Renderer",
+        "command": "malloy.rendererShapeMap",
+        "enablement": "notebookType == malloy-notebook && notebookCellType == code"
+      },
+      {
+        "title": "Point Map",
+        "category": "Malloy Renderer",
+        "command": "malloy.rendererPointMap",
+        "enablement": "notebookType == malloy-notebook && notebookCellType == code"
+      },
+      {
+        "title": "Segment Map",
+        "category": "Malloy Renderer",
+        "command": "malloy.rendererSegmentMap",
+        "enablement": "notebookType == malloy-notebook && notebookCellType == code"
+      },
+      {
+        "title": "JSON",
+        "category": "Malloy Renderer",
+        "command": "malloy.rendererJson",
+        "enablement": "notebookType == malloy-notebook && notebookCellType == code"
+      },
+      {
+        "title": "Dashboard",
+        "category": "Malloy Renderer",
+        "command": "malloy.rendererDashboard",
+        "enablement": "notebookType == malloy-notebook && notebookCellType == code"
       }
     ],
     "menus": {
@@ -185,8 +245,52 @@
           "command": "malloy.newUntitledNotebook",
           "group": "notebook"
         }
+      ],
+      "notebook/cell/title": [
+        {
+          "submenu": "malloy.renderer",
+          "when": "notebookType == malloy-notebook && notebookCellType == code"
+        }
+      ],
+      "malloy.renderer": [
+        {
+          "command": "malloy.rendererTable"
+        },
+        {
+          "command": "malloy.rendererBarChart"
+        },
+        {
+          "command": "malloy.rendererLineChart"
+        },
+        {
+          "command": "malloy.rendererScatterChart"
+        },
+        {
+          "command": "malloy.rendererShapeMap"
+        },
+        {
+          "command": "malloy.rendererPointMap"
+        },
+        {
+          "command": "malloy.rendererSegmentMap"
+        },
+        {
+          "command": "malloy.rendererJson"
+        },
+        {
+          "command": "malloy.rendererList"
+        },
+        {
+          "command": "malloy.rendererDashboard"
+        }
       ]
     },
+    "submenus": [
+      {
+        "id": "malloy.renderer",
+        "label": "Select Renderer"
+      }
+    ],
     "languages": [
       {
         "id": "malloy",
@@ -453,7 +557,6 @@
     "@malloydata/malloy": "0.0.27",
     "@malloydata/render": "0.0.27",
     "@popperjs/core": "^2.11.6",
-    "@types/vscode-notebook-renderer": "^1.72.0",
     "@vscode/webview-ui-toolkit": "^1.2.1",
     "duckdb": "0.7.1",
     "keytar": "7.7.0",
@@ -490,7 +593,8 @@
     "@types/styled-components": "^5.1.19",
     "@types/tar-stream": "^2.2.2",
     "@types/uuid": "^8.3.4",
-    "@types/vscode": "1.68.0",
+    "@types/vscode": "1.72.0",
+    "@types/vscode-notebook-renderer": "^1.72.0",
     "@types/vscode-webview": "^1.57.0",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
     "@typescript-eslint/parser": "^5.48.2",

--- a/src/extension/notebook/commands/renderer.ts
+++ b/src/extension/notebook/commands/renderer.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import * as vscode from 'vscode';
+
+const updateRenderer = (renderer: string): void => {
+  const editor = vscode.window.activeNotebookEditor;
+  const {notebook, selection} = editor;
+  const {metadata} = notebook.cellAt(selection.start);
+  const newMetadata = {...metadata} ?? {};
+  newMetadata['renderer'] = renderer;
+  const edit = new vscode.WorkspaceEdit();
+  const notebookEdit = vscode.NotebookEdit.updateCellMetadata(
+    selection.start,
+    newMetadata
+  );
+  edit.set(notebook.uri, [notebookEdit]);
+  vscode.workspace.applyEdit(edit);
+};
+
+function rendererTable(): void {
+  updateRenderer('table');
+}
+function rendererList(): void {
+  updateRenderer('list');
+}
+function rendererBarChart(): void {
+  updateRenderer('bar_chart');
+}
+function rendererLineChart(): void {
+  updateRenderer('line_chart');
+}
+function rendererScatterChart(): void {
+  updateRenderer('scatter_chart');
+}
+function rendererShapeMap(): void {
+  updateRenderer('shape_map');
+}
+function rendererPointMap(): void {
+  updateRenderer('point_map');
+}
+function rendererSegmentMap(): void {
+  updateRenderer('segment_map');
+}
+function rendererJson(): void {
+  updateRenderer('json');
+}
+function rendererDashboard(): void {
+  updateRenderer('dashboard');
+}
+
+export function registerRendererCommands(context) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('malloy.rendererTable', rendererTable)
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('malloy.rendererList', rendererList)
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('malloy.rendererBarChart', rendererBarChart)
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'malloy.rendererLineChart',
+      rendererLineChart
+    )
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'malloy.rendererScatterChart',
+      rendererScatterChart
+    )
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('malloy.rendererShapeMap', rendererShapeMap)
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('malloy.rendererPointMap', rendererPointMap)
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'malloy.rendererSegmentMap',
+      rendererSegmentMap
+    )
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('malloy.rendererJson', rendererJson)
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'malloy.rendererDashboard',
+      rendererDashboard
+    )
+  );
+}

--- a/src/extension/notebook/malloy_controller.ts
+++ b/src/extension/notebook/malloy_controller.ts
@@ -30,6 +30,7 @@ import {
 } from '@malloydata/malloy';
 import {ConnectionManager} from '../../common/connection_manager';
 import {newUntitledNotebookCommand} from '../commands/new_untitled_notebook';
+import {registerRendererCommands} from './commands/renderer';
 
 const NO_QUERY = 'Model has no queries.';
 
@@ -48,6 +49,8 @@ export function activateNotebookController(
       newUntitledNotebookCommand
     )
   );
+
+  registerRendererCommands(context);
 }
 
 class MalloyController {
@@ -123,8 +126,7 @@ class MalloyController {
         query = runtime.loadQuery(url);
       }
       const results = await query.run();
-
-      let meta = {};
+      let meta = cell.metadata ? {...cell.metadata} : {};
       const style = text.match(/\/\/ --! style ([a-z_]+)/m);
       if (style) {
         meta = {renderer: style[1]};

--- a/src/extension/notebook/malloy_serializer.ts
+++ b/src/extension/notebook/malloy_serializer.ts
@@ -40,6 +40,7 @@ interface RawNotebookCell {
   language: string;
   value: string;
   kind: vscode.NotebookCellKind;
+  metadata?: {[key: string]: unknown};
 }
 
 class MalloySerializer implements vscode.NotebookSerializer {
@@ -56,9 +57,17 @@ class MalloySerializer implements vscode.NotebookSerializer {
       raw = [];
     }
 
-    const cells = raw.map(
-      item => new vscode.NotebookCellData(item.kind, item.value, item.language)
-    );
+    const cells = raw.map(item => {
+      const cell = new vscode.NotebookCellData(
+        item.kind,
+        item.value,
+        item.language
+      );
+      if (item.metadata) {
+        cell.metadata = item.metadata;
+      }
+      return cell;
+    });
 
     return new vscode.NotebookData(cells);
   }
@@ -70,8 +79,8 @@ class MalloySerializer implements vscode.NotebookSerializer {
     const contents: RawNotebookCell[] = [];
 
     for (const cell of data.cells) {
-      const {kind, languageId: language, value} = cell;
-      contents.push({kind, language, value});
+      const {kind, languageId: language, value, metadata} = cell;
+      contents.push({kind, language, value, metadata});
     }
 
     return new TextEncoder().encode(JSON.stringify(contents, null, 2));


### PR DESCRIPTION
Adds a renderer popup to the cell menu. Unfortunately it requires a much newer vscode API, so I will need to check compatibility.

<img width="811" alt="Screenshot 2023-03-16 at 11 35 07 AM" src="https://user-images.githubusercontent.com/2958002/225720008-e426456d-d421-4187-9dae-dbe2b2dfe12e.png">
