### PR TITLE
Extend Malloy help panel with more contexts and links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "duckdb": "0.7.1",
         "keytar": "7.7.0",
         "lodash": "^4.17.21",
-        "markdown-to-jsx": "^7.1.9",
         "node-fetch": "^2.6.6",
         "prismjs": "^1.28.0",
         "react": "^17.0.2",
@@ -10018,17 +10017,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/markdown-to-jsx": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.9.tgz",
-      "integrity": "sha512-x4STVIKIJR0mGgZIZ5RyAeQD7FEZd5tS8m/htbcVGlex32J+hlSLj+ExrHCxP6nRKF1EKbcO7i6WhC1GtOpBlA==",
-      "engines": {
-        "node": ">= 10"
-      },
-      "peerDependencies": {
-        "react": ">= 0.14.0"
       }
     },
     "node_modules/md5": {

--- a/package.json
+++ b/package.json
@@ -562,7 +562,6 @@
     "duckdb": "0.7.1",
     "keytar": "7.7.0",
     "lodash": "^4.17.21",
-    "markdown-to-jsx": "^7.1.9",
     "node-fetch": "^2.6.6",
     "prismjs": "^1.28.0",
     "react": "^17.0.2",

--- a/src/extension/webviews/help_page/App.tsx
+++ b/src/extension/webviews/help_page/App.tsx
@@ -21,17 +21,14 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, {useEffect, useState} from 'react';
+import React, {useEffect} from 'react';
 import styled from 'styled-components';
-import Markdown from 'markdown-to-jsx';
 
 import {HelpMessageType} from '../../../common/message_types';
 import {VSCodeButton} from '@vscode/webview-ui-toolkit/react';
 import {useHelpVSCodeContext} from './help_vscode_context';
-import {COMPLETION_DOCS} from '../../../common/completion_docs';
 
 export const App: React.FC = () => {
-  const [help, setHelp] = useState('');
   const vscode = useHelpVSCodeContext();
 
   // TODO crs this might only be necessary because the MessageManager makes it necessary
@@ -39,40 +36,38 @@ export const App: React.FC = () => {
     vscode.postMessage({type: HelpMessageType.AppReady});
   });
 
-  useEffect(() => {
-    const listener = (event: MessageEvent) => {
-      const {keyword} = event.data;
-      const [_, malloy_keyword] = keyword.split('.');
-      let hint_text = '';
-      if (COMPLETION_DOCS['model_property'][malloy_keyword]) {
-        hint_text = COMPLETION_DOCS['model_property'][malloy_keyword];
-      } else if (COMPLETION_DOCS['query_property'][malloy_keyword]) {
-        hint_text = COMPLETION_DOCS['query_property'][malloy_keyword];
-      } else if (COMPLETION_DOCS['explore_property'][malloy_keyword]) {
-        hint_text = COMPLETION_DOCS['explore_property'][malloy_keyword];
-      }
-      setHelp(hint_text);
-    };
-    window.addEventListener('message', listener);
-    return () => window.removeEventListener('message', listener);
-  });
-
   return (
     <ViewDiv>
-      <ButtonLink href="https://malloydata.github.io/documentation/">
-        View Documentation
-      </ButtonLink>
+      <Help>
+        <h3 id="about-malloy">About Malloy</h3>
+        <p>
+          Malloy is an experimental language for describing data relationships
+          and transformations. It is both a semantic modeling language and a
+          querying language that runs queries against a relational database.
+          Malloy currently supports BigQuery, Postgres, and DuckDB.
+          <br />
+          <br />
+          The installed Visual Studio Code extension supports building Malloy
+          data models, querying and transforming data, and creating simple
+          visualizations and dashboards.
+        </p>
+      </Help>
+      <Help>
+        <h3>Malloy Resources</h3>
+      </Help>
+
       <ButtonLink href="https://malloydata.github.io/documentation/user_guides/basic.html">
         Quick Start Guide
       </ButtonLink>
-      <ButtonLink href="https://github.com/malloydata/malloy-samples/releases">
+      <ButtonLink href="https://malloydata.github.io/documentation/language/sql_to_malloy.html">
+        Language Reference
+      </ButtonLink>
+      <ButtonLink href="https://github.com/malloydata/malloy-samples/releases/latest">
         Download Sample Models
       </ButtonLink>
-      <Help>
-        <h3>Quick Help</h3>
-        {help && <Markdown>{help}</Markdown>}
-        {!help && <span>Select a keyword for quick help.</span>}
-      </Help>
+      <ButtonLink href="https://malloydata.github.io/documentation/index.html">
+        View Documentation
+      </ButtonLink>
     </ViewDiv>
   );
 };


### PR DESCRIPTION
This patch extends the help panel with more contexts and links. Also cleaned up the on-click help messages and dependencies.