### PR TITLE
Delegate building Malloy model to vscode LSP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/db-bigquery": "0.0.30",
-        "@malloydata/db-duckdb": "0.0.30",
-        "@malloydata/db-postgres": "0.0.30",
-        "@malloydata/malloy": "0.0.30",
-        "@malloydata/render": "0.0.30",
+        "@malloydata/db-bigquery": "0.0.31",
+        "@malloydata/db-duckdb": "0.0.31",
+        "@malloydata/db-postgres": "0.0.31",
+        "@malloydata/malloy": "0.0.31",
+        "@malloydata/render": "0.0.31",
         "@popperjs/core": "^2.11.6",
         "@vscode/webview-ui-toolkit": "^1.2.1",
         "duckdb": "0.7.1",
@@ -1732,14 +1732,14 @@
       }
     },
     "node_modules/@malloydata/db-bigquery": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@malloydata/db-bigquery/-/db-bigquery-0.0.30.tgz",
-      "integrity": "sha512-r1pEIb3OWjMhH20H45IwOdchGvOKZB9wVu9ejyUkdzUmQgZm56pYOpdBMUZZjZqi+BzcKldcQDmTaJO700Y+0A==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@malloydata/db-bigquery/-/db-bigquery-0.0.31.tgz",
+      "integrity": "sha512-zR7ZFkXEbO3386DTUf+U4a6FoHOpM/QG9+HkSOX24EiWEf4b4Gwwee2OGJsj7NYRgQZxFFIHv7+sQNVRvKbMMg==",
       "dependencies": {
         "@google-cloud/bigquery": "^5.5.0",
         "@google-cloud/common": "^3.6.0",
         "@google-cloud/paginator": "^4.0.1",
-        "@malloydata/malloy": "^0.0.30",
+        "@malloydata/malloy": "^0.0.31",
         "gaxios": "^4.2.0"
       },
       "engines": {
@@ -1747,12 +1747,12 @@
       }
     },
     "node_modules/@malloydata/db-duckdb": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@malloydata/db-duckdb/-/db-duckdb-0.0.30.tgz",
-      "integrity": "sha512-/ZW6MO9e6+O0IpOt9B+Qdm/unE02kqkcza/dvLa9lXR62E2iTUy3GHP/RibU++SCHLzOBZ0/kDe2IglDjI3I2w==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@malloydata/db-duckdb/-/db-duckdb-0.0.31.tgz",
+      "integrity": "sha512-MD03lUlICE1/vc6PR9QOaDK9mIZezsXmA7lJokncDzlBLf4UZWZIHVWI1NpLK/k5yokQZb8C6BBdKY6bT6Qmdw==",
       "dependencies": {
         "@malloydata/duckdb-wasm": "0.0.1",
-        "@malloydata/malloy": "^0.0.30",
+        "@malloydata/malloy": "^0.0.31",
         "apache-arrow": "^11.0.0",
         "duckdb": "0.7.1",
         "web-worker": "^1.2.0"
@@ -1762,11 +1762,11 @@
       }
     },
     "node_modules/@malloydata/db-postgres": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@malloydata/db-postgres/-/db-postgres-0.0.30.tgz",
-      "integrity": "sha512-IvYTTwwPaV8Ww8S34FZbiewHgjeXscIKeNGO07Pnb4P8N/yXprXsiXUMPi20rKaCZsFjcUMxxsDouJ71r0JrZg==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@malloydata/db-postgres/-/db-postgres-0.0.31.tgz",
+      "integrity": "sha512-xPdg6prlZFqsCIsu3touhc26fFiI3zBgUql8MQaUZkOSASh9OfOzqQKaeR8BszvaKRnYXz+7F7eHcNmpvrfKDw==",
       "dependencies": {
-        "@malloydata/malloy": "^0.0.30",
+        "@malloydata/malloy": "^0.0.31",
         "@types/pg": "^8.6.1",
         "pg": "^8.7.1",
         "pg-query-stream": "4.2.3"
@@ -1781,9 +1781,9 @@
       }
     },
     "node_modules/@malloydata/malloy": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.30.tgz",
-      "integrity": "sha512-aUx8E+5C36WgojaDn5+pB1Uwak9WgKpJ1V8uwp1euMMTUS2XsUOomuOFfe4jdT16AddfdXAvCjm4jvJzSu+oVA==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.31.tgz",
+      "integrity": "sha512-FBXSl2umvWX35Q6LEVY3b8n6JkCdKak5SQJtz++Q7Jpu1m5Qt5W9M8LRIsWqbDKxlxCpM48em9wAn4jiS5UShA==",
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4",
         "assert": "^2.0.0",
@@ -1796,11 +1796,11 @@
       }
     },
     "node_modules/@malloydata/render": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@malloydata/render/-/render-0.0.30.tgz",
-      "integrity": "sha512-QgsZhLV7tzcyHJfx3NkAsayK7huFntRpptt46NBpttyyBUUZ3Xm+95BxexwYhHJyTNP5AtZAJndl/vecl+TmLg==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@malloydata/render/-/render-0.0.31.tgz",
+      "integrity": "sha512-Qp6ctrY8NaMs9SthmVHk1C7kXv1DL39hnajrKTYEDglvQ02P8SyflZ3hdWAsQcO7xgQ/Bvq1UExAHiw6tg5LgQ==",
       "dependencies": {
-        "@malloydata/malloy": "^0.0.30",
+        "@malloydata/malloy": "^0.0.31",
         "lodash": "^4.17.20",
         "us-atlas": "^3.0.0",
         "vega": "^5.21.0",

--- a/package.json
+++ b/package.json
@@ -552,11 +552,11 @@
     ]
   },
   "dependencies": {
-    "@malloydata/db-bigquery": "0.0.30",
-    "@malloydata/db-duckdb": "0.0.30",
-    "@malloydata/db-postgres": "0.0.30",
-    "@malloydata/malloy": "0.0.30",
-    "@malloydata/render": "0.0.30",
+    "@malloydata/db-bigquery": "0.0.31",
+    "@malloydata/db-duckdb": "0.0.31",
+    "@malloydata/db-postgres": "0.0.31",
+    "@malloydata/malloy": "0.0.31",
+    "@malloydata/render": "0.0.31",
     "@popperjs/core": "^2.11.6",
     "@vscode/webview-ui-toolkit": "^1.2.1",
     "duckdb": "0.7.1",

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -48,3 +48,8 @@ export interface CellData {
   uri: string;
   text: string;
 }
+
+export interface BuildModelRequest {
+  uri: string;
+  version: number;
+}

--- a/src/extension/browser/extension_browser.ts
+++ b/src/extension/browser/extension_browser.ts
@@ -47,7 +47,8 @@ export let extensionModeProduction: boolean;
 export function activate(context: vscode.ExtensionContext): void {
   const urlReader = new VSCodeURLReader();
   setupWorker(context);
-  setupSubscriptions(context, urlReader, connectionManager, worker);
+  setupLanguageServer(context);
+  setupSubscriptions(context, urlReader, connectionManager, worker, client);
 
   const connectionsTree = new ConnectionsProvider(context, connectionManager);
   context.subscriptions.push(
@@ -68,7 +69,6 @@ export function activate(context: vscode.ExtensionContext): void {
       editConnectionsCommand
     )
   );
-  setupLanguageServer(context);
 }
 
 export async function deactivate(): Promise<void> | undefined {

--- a/src/extension/node/extension_node.ts
+++ b/src/extension/node/extension_node.ts
@@ -60,7 +60,8 @@ export function activate(context: vscode.ExtensionContext): void {
   const urlReader = new VSCodeURLReader();
   cloudshellEnv();
   setupWorker(context);
-  setupSubscriptions(context, urlReader, connectionManager, worker);
+  setupLanguageServer(context);
+  setupSubscriptions(context, urlReader, connectionManager, worker, client);
 
   const connectionsTree = new ConnectionsProvider(context, connectionManager);
 
@@ -89,8 +90,6 @@ export function activate(context: vscode.ExtensionContext): void {
       }
     })
   );
-
-  setupLanguageServer(context);
 }
 
 export async function deactivate(): Promise<void> | undefined {

--- a/src/extension/subscriptions.ts
+++ b/src/extension/subscriptions.ts
@@ -45,6 +45,7 @@ import {MALLOY_EXTENSION_STATE} from './state';
 import {activateNotebookSerializer} from './notebook/malloy_serializer';
 import {activateNotebookController} from './notebook/malloy_controller';
 import {BaseWorker} from '../common/worker_message_types';
+import {CommonLanguageClient} from 'vscode-languageclient';
 
 function getNewClientId(): string {
   return uuid();
@@ -54,7 +55,8 @@ export const setupSubscriptions = (
   context: vscode.ExtensionContext,
   urlReader: URLReader,
   connectionManager: ConnectionManager,
-  worker: BaseWorker
+  worker: BaseWorker,
+  client: CommonLanguageClient
 ) => {
   MALLOY_EXTENSION_STATE.setExtensionUri(context.extensionUri);
 
@@ -104,7 +106,12 @@ export const setupSubscriptions = (
     )
   );
 
-  const schemaTree = new SchemaProvider(context, connectionManager, urlReader);
+  const schemaTree = new SchemaProvider(
+    context,
+    connectionManager,
+    urlReader,
+    client
+  );
 
   context.subscriptions.push(
     vscode.window.registerTreeDataProvider('malloySchema', schemaTree)

--- a/src/extension/tree_views/schema_view.ts
+++ b/src/extension/tree_views/schema_view.ts
@@ -26,14 +26,12 @@ import {Utils} from 'vscode-uri';
 
 import {
   Explore,
-  Runtime,
   JoinRelationship,
   Field,
   QueryField,
   AtomicField,
   URLReader,
-  Model,
-  ModelMaterializer,
+  SerializedExplore,
 } from '@malloydata/malloy';
 import numberIcon from '../../media/number.svg';
 import numberAggregateIcon from '../../media/number-aggregate.svg';
@@ -47,6 +45,8 @@ import manyToOneIcon from '../../media/many_to_one.svg';
 import oneToOneIcon from '../../media/one_to_one.svg';
 import {MALLOY_EXTENSION_STATE} from '../state';
 import {ConnectionManager} from '../../common/connection_manager';
+import {CommonLanguageClient} from 'vscode-languageclient/node';
+import {BuildModelRequest} from '../../common/types';
 
 export class SchemaProvider
   implements vscode.TreeDataProvider<ExploreItem | FieldItem>
@@ -57,7 +57,8 @@ export class SchemaProvider
   constructor(
     private context: vscode.ExtensionContext,
     private connectionManager: ConnectionManager,
-    private urlReader: URLReader
+    private urlReader: URLReader,
+    private client: CommonLanguageClient
   ) {
     this.resultCache = new Map();
   }
@@ -121,7 +122,8 @@ export class SchemaProvider
       const explores = await getStructs(
         this.connectionManager,
         this.urlReader,
-        document
+        document,
+        this.client
       );
       if (explores === undefined) {
         return this.resultCache.get(cacheKey) || [];
@@ -146,40 +148,22 @@ export class SchemaProvider
 async function getStructs(
   connectionManager: ConnectionManager,
   reader: URLReader,
-  document: vscode.TextDocument
+  document: vscode.TextDocument,
+  client: CommonLanguageClient
 ): Promise<Explore[] | undefined> {
-  const url = new URL(document.uri.toString());
   try {
-    const runtime = new Runtime(
-      reader,
-      connectionManager.getConnectionLookup(url)
+    const request: BuildModelRequest = {
+      uri: document.uri.toString(),
+      version: document.version,
+    };
+    const serialized_explores: SerializedExplore[] = await client.sendRequest(
+      'malloy/fetchModel',
+      request
     );
-    let model: Model;
-    if (url.protocol === 'vscode-notebook-cell:') {
-      const notebook = vscode.workspace.notebookDocuments.find(
-        notebook => notebook.uri.path === document.uri.path
-      );
-      let mm: ModelMaterializer | null = null;
-      for (const cell of notebook.getCells()) {
-        const {uri: cellUri} = cell.document;
-        if (cell.kind === vscode.NotebookCellKind.Code) {
-          const cellUrl = new URL(cellUri.toString());
-          if (mm) {
-            mm = mm.extendModel(cellUrl);
-          } else {
-            mm = runtime.loadModel(cellUrl);
-          }
-        }
-        if (cellUri.fragment === document.uri.fragment) {
-          break;
-        }
-      }
-      model = await mm.getModel();
-    } else {
-      model = await runtime.getModel(url);
-    }
-
-    return Object.values(model.explores).sort(exploresByName);
+    const explores = serialized_explores.map(explore =>
+      Explore.fromJSON(explore)
+    );
+    return Object.values(explores).sort(exploresByName);
   } catch (error) {
     return undefined;
   }

--- a/src/server/definitions/definitions.ts
+++ b/src/server/definitions/definitions.ts
@@ -35,9 +35,8 @@ export async function getMalloyDefinitionReference(
 ): Promise<Location[]> {
   try {
     const model = await translateCache.translateWithCache(
-      connectionManager,
-      document,
-      documents
+      document.uri,
+      document.version
     );
     const reference = model.getReference(position);
     const location = reference?.definition.location;

--- a/src/server/diagnostics/diagnostics.ts
+++ b/src/server/diagnostics/diagnostics.ts
@@ -50,11 +50,7 @@ export async function getMalloyDiagnostics(
   let errors: LogMessage[] = [];
 
   try {
-    await translateCache.translateWithCache(
-      connectionManager,
-      document,
-      documents
-    );
+    await translateCache.translateWithCache(document.uri, document.version);
   } catch (error) {
     if (error instanceof MalloyError) {
       errors = error.log;

--- a/src/server/init.ts
+++ b/src/server/init.ts
@@ -93,7 +93,11 @@ export const initServer = (
     return result;
   });
 
-  const translateCache = new TranslateCache(connection);
+  const translateCache = new TranslateCache(
+    documents,
+    connection,
+    connectionManager
+  );
 
   async function diagnoseDocument(document: TextDocument) {
     if (haveConnectionsBeenSet) {


### PR DESCRIPTION
This patch consolidates building Malloy model onto the vscode LSP.
- Lang client issues an IPC to the lang server to request an array of `Explore` in JSON strings and consumes them.
- Reordered the initialization of the lang server so that the lang client instance can be passed to the `SchemaProvider`.
- Cleaned up a few routines, as some of the input parameters are unused.

The Malloy side change is [here](https://github.com/malloydata/malloy/pull/1081).

Fixes malloydata/malloy-vscode-extension#104