### PR TITLE
it appears as though at some point we moved from having just "server.…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,7 +51,7 @@
       "skipFiles": ["<node_internals>/**"],
       "restart": true,
       "smartStep": false,
-      "outFiles": ["${workspaceRoot}/dist/server_node.js"]
+      "outFiles": ["${workspaceRoot}/dist/server_*.js"]
     },
     {
       "type": "node",
@@ -61,7 +61,7 @@
       "skipFiles": ["<node_internals>/**"],
       "restart": true,
       "smartStep": false,
-      "outFiles": ["${workspaceRoot}/dist/worker_node.js"]
+      "outFiles": ["${workspaceRoot}/dist/worker_*.js"]
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "skipFiles": ["<node_internals>/**"],
       "outFiles": ["${workspaceFolder}/dist/*.js"],
       "preLaunchTask": "build-extension-task",
-      "sourceMaps": true
+      "sourceMaps": true,
     },
     {
       "name": "Run VSCode Extension (and Debug Webviews)",
@@ -51,7 +51,7 @@
       "skipFiles": ["<node_internals>/**"],
       "restart": true,
       "smartStep": false,
-      "outFiles": ["${workspaceRoot}/dist/server.js"]
+      "outFiles": ["${workspaceRoot}/dist/server_node.js"]
     },
     {
       "type": "node",
@@ -61,7 +61,7 @@
       "skipFiles": ["<node_internals>/**"],
       "restart": true,
       "smartStep": false,
-      "outFiles": ["${workspaceRoot}/dist/worker.js"]
+      "outFiles": ["${workspaceRoot}/dist/worker_node.js"]
     }
   ]
 }


### PR DESCRIPTION
…js" and "worker.js" to "server_node" or "server_web" etc. This change enables attaching language server or web worker on the default debug launch (node)