### PR TITLE
wrap SQL so that it remains in window 

### DIFF
--- a/src/extension/webviews/query_page/App.tsx
+++ b/src/extension/webviews/query_page/App.tsx
@@ -266,7 +266,7 @@ export const App: React.FC = () => {
               dangerouslySetInnerHTML={{
                 __html: Prism.highlight(sql, Prism.languages['sql'], 'sql'),
               }}
-              style={{margin: '10px'}}
+              style={{margin: '10px', whiteSpace: 'break-spaces'}}
             />
           </PrismContainer>
         </Scroll>


### PR DESCRIPTION
instead of creating (sometimes long) horizontal scrollbar. copy functionality (ctrl-c or the copy button bottom right) is retained.

before:

![Screenshot 2023-04-25 at 8 27 46 AM](https://user-images.githubusercontent.com/108260/234330793-80ce82ac-13b5-4eed-bfa0-a9babe1fc27b.png)

after:

![Screenshot 2023-04-25 at 8 27 18 AM](https://user-images.githubusercontent.com/108260/234330818-e22170b8-f91b-4b9e-bb0a-4cf8c1becbb1.png)

