### PR TITLE
Better theme support

### DIFF
--- a/src/extension/webviews/msql_query_page/App.tsx
+++ b/src/extension/webviews/msql_query_page/App.tsx
@@ -21,13 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import React, {
-  DOMElement,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import styled from 'styled-components';
 import {
   EvaluatedMSQLStatement,
@@ -159,7 +153,10 @@ export const App: React.FC = () => {
                       dataStyles: {},
                     }
                   );
-                  evaluatedStatement.renderedHTML = renderedTable;
+                  const html = document.createElement('div');
+                  html.style.fontSize = '11px';
+                  html.appendChild(renderedTable);
+                  evaluatedStatement.renderedHTML = html;
                 } else if (evaluatedStatement.results.rows.length === 0) {
                   const html = document.createElement('span');
                   html.innerText = 'Statement completed';
@@ -353,7 +350,7 @@ const DOMElement: React.FC<{element: HTMLElement}> = ({element}) => {
     }
   }, [element]);
 
-  return <div style={{fontSize: 11}} ref={ref}></div>;
+  return <div ref={ref} />;
 };
 
 const Warning = styled.div`
@@ -376,10 +373,9 @@ const Error = styled.div<ErrorProps>`
 
 const ResultControlsBar = styled.div`
   display: flex;
-  border-bottom: 1px solid #efefef;
+  border-bottom: 1px solid var(--vscode-notifications-border);
   justify-content: space-between;
   align-items: center;
-  color: #b1b1b1;
   padding: 0 10px;
   user-select: none;
 `;
@@ -395,7 +391,8 @@ const ResultControlsItems = styled.div`
 `;
 
 const ResultsContainer = styled.div`
-  border-bottom: 1px solid #d8d5d5;
-  color: #b1b1b1;
+  border-bottom: 1px solid var(--vscode-notifications-border);
+  font-family: var(--vscode-editor-font-family);
+  font-size: var(--vscode-editor-font-size);
   padding: 12px 12px;
 `;

--- a/src/extension/webviews/query_page/App.tsx
+++ b/src/extension/webviews/query_page/App.tsx
@@ -322,7 +322,7 @@ function getStatusLabel(status: Status) {
 
 function getStyledHTML(html: HTMLElement): string {
   const resolveStyles = getComputedStyle(html);
-  const styles = `<style>
+  const styles = /* html */ `<style>
   :root {
     --malloy-font-family: ${resolveStyles.getPropertyValue(
       '--malloy-font-family'


### PR DESCRIPTION
MalloySQL JSON results were hard to see in light mode, and didn't respect the user's selected font. Adds some style tweaks for that.

# Before

<img width="1103" alt="Screenshot 2023-06-08 at 12 51 51 PM" src="https://github.com/malloydata/malloy-vscode-extension/assets/2958002/ea9a571f-1408-41c2-b4d1-3ab1d78bd68a">
<img width="1098" alt="Screenshot 2023-06-08 at 12 52 12 PM" src="https://github.com/malloydata/malloy-vscode-extension/assets/2958002/70e551cd-6694-4edf-9b9d-d50ad7e61ac3">

# After
<img width="980" alt="Screenshot 2023-06-08 at 12 58 03 PM" src="https://github.com/malloydata/malloy-vscode-extension/assets/2958002/d765f69e-59d5-4119-9dc9-62a013cb75dc">
<img width="982" alt="Screenshot 2023-06-08 at 12 58 37 PM" src="https://github.com/malloydata/malloy-vscode-extension/assets/2958002/a8be589c-68a0-4fc0-9301-0f82b1b4d9e4">

