### PR TITLE
Revert "Add arm64 linux duckdb"

### DIFF
--- a/scripts/utils/fetch_duckdb.ts
+++ b/scripts/utils/fetch_duckdb.ts
@@ -34,7 +34,6 @@ export const targetDuckDBMap: Record<string, string> = {
   'darwin-arm64': `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-arm64.node`,
   'darwin-x64': `duckdb-v${DUCKDB_VERSION}-node-v93-darwin-x64.node`,
   'linux-x64': `duckdb-v${DUCKDB_VERSION}-node-v93-linux-x64.node`,
-  'linux-arm64': `duckdb-v${DUCKDB_VERSION}-node-v93-linux-arm64.node`,
   'win32-x64': `duckdb-v${DUCKDB_VERSION}-node-v93-win32-x64.node`,
 };
 


### PR DESCRIPTION
Reverts malloydata/malloy-vscode-extension#159

DuckDB doesn't appear to be building linux-arm64 for node.