### PR TITLE
Fix DuckDB Malloy versoin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@malloydata/db-bigquery": "0.0.46",
-        "@malloydata/db-duckdb": "0.0.46",
-        "@malloydata/db-postgres": "0.0.46",
-        "@malloydata/malloy": "0.0.46",
-        "@malloydata/malloy-sql": "0.0.46",
-        "@malloydata/render": "0.0.46",
+        "@malloydata/db-bigquery": "0.0.47",
+        "@malloydata/db-duckdb": "0.0.47",
+        "@malloydata/db-postgres": "0.0.47",
+        "@malloydata/malloy": "0.0.47",
+        "@malloydata/malloy-sql": "0.0.47",
+        "@malloydata/render": "0.0.47",
         "@popperjs/core": "^2.11.6",
         "@vscode/webview-ui-toolkit": "^1.2.1",
         "duckdb": "0.8.1",
@@ -2444,14 +2444,14 @@
       }
     },
     "node_modules/@malloydata/db-bigquery": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/db-bigquery/-/db-bigquery-0.0.46.tgz",
-      "integrity": "sha512-mTOiHkGpbz5PlGrW/C2l6IwolRZE4B6nAn6ePImlEF24U3wQJGc36rNCqbJ/Sn2LzFRKhmMOLiVUy00hSTXzgA==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/db-bigquery/-/db-bigquery-0.0.47.tgz",
+      "integrity": "sha512-uMUp5E+tBzA0zxHn+fymF2ZR+SODcTkbe56FQDZFmeagLpKQ/7FuCGF7PymtQrhqM61nm7f3neu7VHj7o9fNpw==",
       "dependencies": {
         "@google-cloud/bigquery": "^5.5.0",
         "@google-cloud/common": "^3.6.0",
         "@google-cloud/paginator": "^4.0.1",
-        "@malloydata/malloy": "^0.0.46",
+        "@malloydata/malloy": "^0.0.47",
         "gaxios": "^4.2.0"
       },
       "engines": {
@@ -2471,12 +2471,12 @@
       }
     },
     "node_modules/@malloydata/db-duckdb": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/db-duckdb/-/db-duckdb-0.0.46.tgz",
-      "integrity": "sha512-2Vch1sPFX9/czWwGjRH4BDyF+8UlA/bdzhaP4MHHkjmtdEBjJMFdEBA+pH8qdrnPZKNUzlbSQye98XJat0mcbQ==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/db-duckdb/-/db-duckdb-0.0.47.tgz",
+      "integrity": "sha512-A1QOcUbdHWHBq2W63W6zQlj0lAjuKS5w6TStNOW9E5QEk5TndgnqpbAZjUM2p/1Ck+q5oeqqtJl5R5V7Cqyl6g==",
       "dependencies": {
         "@malloydata/duckdb-wasm": "0.0.2",
-        "@malloydata/malloy": "^0.0.40",
+        "@malloydata/malloy": "^0.0.47",
         "apache-arrow": "^11.0.0",
         "duckdb": "0.8.1",
         "web-worker": "^1.2.0"
@@ -2485,27 +2485,12 @@
         "node": ">=11"
       }
     },
-    "node_modules/@malloydata/db-duckdb/node_modules/@malloydata/malloy": {
-      "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.40.tgz",
-      "integrity": "sha512-QjU+B/lbFVM2WVqlS+rKadr/CpkMGUICMJl9Ox1VAyGdul/XqtmfUUJjbgnU0lqap+F+3TyPOewhK8r0hWmilA==",
-      "dependencies": {
-        "antlr4ts": "^0.5.0-alpha.4",
-        "assert": "^2.0.0",
-        "lodash": "^4.17.20",
-        "luxon": "^1.26.0",
-        "md5": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@malloydata/db-postgres": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/db-postgres/-/db-postgres-0.0.46.tgz",
-      "integrity": "sha512-2Hn7fM1JlxaFen7ZHoNavE5c2d9hY/32CCa5zrPpe1EQXOzH2H6kHEiKSl668gS3lD6kdSVV3USwo0M/Q9P2iQ==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/db-postgres/-/db-postgres-0.0.47.tgz",
+      "integrity": "sha512-ypn2ILY1OXK1exKHKXaRofN0s2rMNuI3PaVRWsILUyJOK62WgR7nbiLjg1L0lH8Ix/hegbO/GjmUEdO+S1dmXA==",
       "dependencies": {
-        "@malloydata/malloy": "^0.0.46",
+        "@malloydata/malloy": "^0.0.47",
         "@types/pg": "^8.6.1",
         "pg": "^8.7.1",
         "pg-query-stream": "4.2.3"
@@ -2520,9 +2505,9 @@
       }
     },
     "node_modules/@malloydata/malloy": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.46.tgz",
-      "integrity": "sha512-T9oXMusdRE5qvGwJVf92nZUnlKxfvWSnrj69WZmTixeY2n5P4ijIx5DKtlo9yU2FvY2b8nxpijIiBXe2QYEjrg==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.47.tgz",
+      "integrity": "sha512-AyhIj8DhDNFg4K7iRgAnDsIYaL2PkNw6AIng8mpOrRvh980h5QkzcdWHjDuS31EYQWFHMvQY+mESJuLsHkGFhg==",
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4",
         "assert": "^2.0.0",
@@ -2535,19 +2520,19 @@
       }
     },
     "node_modules/@malloydata/malloy-sql": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy-sql/-/malloy-sql-0.0.46.tgz",
-      "integrity": "sha512-ec7s7XB4IcQP6R8SJHtZzoMu2x4pKDYKGfkmD7zfkCz0xZIFJVmLN9ppb2S5fNqXSujmreZhRM0eszC6EpxmjQ==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy-sql/-/malloy-sql-0.0.47.tgz",
+      "integrity": "sha512-Walsa3GkYzHGhzvlKAFE8uzikig1YyLUxH7pFBC4/zTiLMuf+PwpE4egbk3OH0n1UdT+TAkkjaBda4LEZ1e8uA==",
       "dependencies": {
-        "@malloydata/malloy": "^0.0.46"
+        "@malloydata/malloy": "^0.0.47"
       }
     },
     "node_modules/@malloydata/render": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/render/-/render-0.0.46.tgz",
-      "integrity": "sha512-fBzxVOQBnTUBcnmY4VpqG+AX25OO3gcecdOIbHy6wTG/NZA2JEOm+NalLHud5544Wxoq2goyC8zLdbKqTncGKg==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/render/-/render-0.0.47.tgz",
+      "integrity": "sha512-ABCtTw5SnUyLGLqmZYHdGO0sTqOvn07AyR67CwUQPOqgY56s1sr97owRAQwRQ3fpJQNNSjjOxZ0i6flcpBe6Zg==",
       "dependencies": {
-        "@malloydata/malloy": "^0.0.46",
+        "@malloydata/malloy": "^0.0.47",
         "@types/luxon": "^2.4.0",
         "lodash": "^4.17.20",
         "luxon": "^2.4.0",
@@ -20044,14 +20029,14 @@
       }
     },
     "@malloydata/db-bigquery": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/db-bigquery/-/db-bigquery-0.0.46.tgz",
-      "integrity": "sha512-mTOiHkGpbz5PlGrW/C2l6IwolRZE4B6nAn6ePImlEF24U3wQJGc36rNCqbJ/Sn2LzFRKhmMOLiVUy00hSTXzgA==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/db-bigquery/-/db-bigquery-0.0.47.tgz",
+      "integrity": "sha512-uMUp5E+tBzA0zxHn+fymF2ZR+SODcTkbe56FQDZFmeagLpKQ/7FuCGF7PymtQrhqM61nm7f3neu7VHj7o9fNpw==",
       "requires": {
         "@google-cloud/bigquery": "^5.5.0",
         "@google-cloud/common": "^3.6.0",
         "@google-cloud/paginator": "^4.0.1",
-        "@malloydata/malloy": "^0.0.46",
+        "@malloydata/malloy": "^0.0.47",
         "gaxios": "^4.2.0"
       },
       "dependencies": {
@@ -20067,37 +20052,23 @@
       }
     },
     "@malloydata/db-duckdb": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/db-duckdb/-/db-duckdb-0.0.46.tgz",
-      "integrity": "sha512-2Vch1sPFX9/czWwGjRH4BDyF+8UlA/bdzhaP4MHHkjmtdEBjJMFdEBA+pH8qdrnPZKNUzlbSQye98XJat0mcbQ==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/db-duckdb/-/db-duckdb-0.0.47.tgz",
+      "integrity": "sha512-A1QOcUbdHWHBq2W63W6zQlj0lAjuKS5w6TStNOW9E5QEk5TndgnqpbAZjUM2p/1Ck+q5oeqqtJl5R5V7Cqyl6g==",
       "requires": {
         "@malloydata/duckdb-wasm": "0.0.2",
-        "@malloydata/malloy": "^0.0.40",
+        "@malloydata/malloy": "^0.0.47",
         "apache-arrow": "^11.0.0",
         "duckdb": "0.8.1",
         "web-worker": "^1.2.0"
-      },
-      "dependencies": {
-        "@malloydata/malloy": {
-          "version": "0.0.40",
-          "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.40.tgz",
-          "integrity": "sha512-QjU+B/lbFVM2WVqlS+rKadr/CpkMGUICMJl9Ox1VAyGdul/XqtmfUUJjbgnU0lqap+F+3TyPOewhK8r0hWmilA==",
-          "requires": {
-            "antlr4ts": "^0.5.0-alpha.4",
-            "assert": "^2.0.0",
-            "lodash": "^4.17.20",
-            "luxon": "^1.26.0",
-            "md5": "^2.3.0"
-          }
-        }
       }
     },
     "@malloydata/db-postgres": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/db-postgres/-/db-postgres-0.0.46.tgz",
-      "integrity": "sha512-2Hn7fM1JlxaFen7ZHoNavE5c2d9hY/32CCa5zrPpe1EQXOzH2H6kHEiKSl668gS3lD6kdSVV3USwo0M/Q9P2iQ==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/db-postgres/-/db-postgres-0.0.47.tgz",
+      "integrity": "sha512-ypn2ILY1OXK1exKHKXaRofN0s2rMNuI3PaVRWsILUyJOK62WgR7nbiLjg1L0lH8Ix/hegbO/GjmUEdO+S1dmXA==",
       "requires": {
-        "@malloydata/malloy": "^0.0.46",
+        "@malloydata/malloy": "^0.0.47",
         "@types/pg": "^8.6.1",
         "pg": "^8.7.1",
         "pg-query-stream": "4.2.3"
@@ -20112,9 +20083,9 @@
       }
     },
     "@malloydata/malloy": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.46.tgz",
-      "integrity": "sha512-T9oXMusdRE5qvGwJVf92nZUnlKxfvWSnrj69WZmTixeY2n5P4ijIx5DKtlo9yU2FvY2b8nxpijIiBXe2QYEjrg==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy/-/malloy-0.0.47.tgz",
+      "integrity": "sha512-AyhIj8DhDNFg4K7iRgAnDsIYaL2PkNw6AIng8mpOrRvh980h5QkzcdWHjDuS31EYQWFHMvQY+mESJuLsHkGFhg==",
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4",
         "assert": "^2.0.0",
@@ -20124,19 +20095,19 @@
       }
     },
     "@malloydata/malloy-sql": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/malloy-sql/-/malloy-sql-0.0.46.tgz",
-      "integrity": "sha512-ec7s7XB4IcQP6R8SJHtZzoMu2x4pKDYKGfkmD7zfkCz0xZIFJVmLN9ppb2S5fNqXSujmreZhRM0eszC6EpxmjQ==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/malloy-sql/-/malloy-sql-0.0.47.tgz",
+      "integrity": "sha512-Walsa3GkYzHGhzvlKAFE8uzikig1YyLUxH7pFBC4/zTiLMuf+PwpE4egbk3OH0n1UdT+TAkkjaBda4LEZ1e8uA==",
       "requires": {
-        "@malloydata/malloy": "^0.0.46"
+        "@malloydata/malloy": "^0.0.47"
       }
     },
     "@malloydata/render": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@malloydata/render/-/render-0.0.46.tgz",
-      "integrity": "sha512-fBzxVOQBnTUBcnmY4VpqG+AX25OO3gcecdOIbHy6wTG/NZA2JEOm+NalLHud5544Wxoq2goyC8zLdbKqTncGKg==",
+      "version": "0.0.47",
+      "resolved": "https://registry.npmjs.org/@malloydata/render/-/render-0.0.47.tgz",
+      "integrity": "sha512-ABCtTw5SnUyLGLqmZYHdGO0sTqOvn07AyR67CwUQPOqgY56s1sr97owRAQwRQ3fpJQNNSjjOxZ0i6flcpBe6Zg==",
       "requires": {
-        "@malloydata/malloy": "^0.0.46",
+        "@malloydata/malloy": "^0.0.47",
         "@types/luxon": "^2.4.0",
         "lodash": "^4.17.20",
         "luxon": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -618,12 +618,12 @@
     ]
   },
   "dependencies": {
-    "@malloydata/db-bigquery": "0.0.46",
-    "@malloydata/db-duckdb": "0.0.46",
-    "@malloydata/db-postgres": "0.0.46",
-    "@malloydata/malloy": "0.0.46",
-    "@malloydata/malloy-sql": "0.0.46",
-    "@malloydata/render": "0.0.46",
+    "@malloydata/db-bigquery": "0.0.47",
+    "@malloydata/db-duckdb": "0.0.47",
+    "@malloydata/db-postgres": "0.0.47",
+    "@malloydata/malloy": "0.0.47",
+    "@malloydata/malloy-sql": "0.0.47",
+    "@malloydata/render": "0.0.47",
     "@popperjs/core": "^2.11.6",
     "@vscode/webview-ui-toolkit": "^1.2.1",
     "duckdb": "0.8.1",

--- a/src/common/connections/browser/connection_factory.ts
+++ b/src/common/connections/browser/connection_factory.ts
@@ -74,7 +74,7 @@ export class WebConnectionFactory implements ConnectionFactory {
           const duckDBConnection: DuckDBWASMConnection =
             await createDuckDbWasmConnection(connectionConfig, configOptions);
           duckDBConnection.registerRemoteTableCallback(remoteTableCallback);
-          connection = duckDBConnection as TestableConnection;
+          connection = duckDBConnection;
         }
         break;
     }

--- a/src/common/connections/node/connection_factory.ts
+++ b/src/common/connections/node/connection_factory.ts
@@ -81,10 +81,10 @@ export class DesktopConnectionFactory implements ConnectionFactory {
         break;
       }
       case ConnectionBackend.DuckDB: {
-        connection = (await createDuckDbConnection(
+        connection = await createDuckDbConnection(
           connectionConfig,
           configOptions
-        )) as TestableConnection;
+        );
         break;
       }
     }


### PR DESCRIPTION
The type coercion was only necessary because @malloydata/db-duckdb was using an entirely different version of @malloydata/malloy as everything else. Oops.