### PR TITLE
Prevent error when computing document symbols on intermediate Malloy …

### DIFF
--- a/src/server/symbols/symbols.ts
+++ b/src/server/symbols/symbols.ts
@@ -29,7 +29,7 @@ import {parseWithCache} from '../parse_cache';
 function mapSymbol(symbol: MalloyDocumentSymbol): DocumentSymbol {
   const type = symbol.type;
   return {
-    name: symbol.name,
+    name: symbol.name || 'unnamed',
     range: symbol.range.toJSON(),
     detail: symbol.type,
     kind:


### PR DESCRIPTION
…code where a source object appears with no name