### PR TITLE
Try shift-enter as Run hotkey

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,6 +246,13 @@
         }
       ]
     },
+    "keybindings": [
+      {
+        "command": "malloy.runQueryAtCursor",
+        "key": "shift+enter",
+        "when": "editorTextFocus && editorLangId == malloy && !findInputFocussed && !replaceInputFocussed"
+      }
+    ],
     "languages": [
       {
         "id": "malloy",


### PR DESCRIPTION
Figured this out moments after I merged https://github.com/malloydata/malloy-vscode-extension/pull/216