### PR TITLE
Run at cursor tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "keybindings": [
       {
         "command": "malloy.runQueryAtCursor",
-        "key": "shift+enter",
+        "key": "ctrl+enter",
         "when": "editorTextFocus && editorLangId == malloy && !findInputFocussed && !replaceInputFocussed"
       }
     ],

--- a/src/server/init.ts
+++ b/src/server/init.ts
@@ -159,7 +159,7 @@ export const initServer = (
     'malloy/findLensesAt',
     ({uri, position}: {uri: string; position: Position}) => {
       const document = documents.get(uri);
-      if (document) {
+      if (document && position) {
         return findMalloyLensesAt(document, position);
       } else {
         return [];


### PR DESCRIPTION
* ctrl+enter instead of shift+enter to match notebooks
* Fix error when cursor position is unknown