### PR TITLE
Set panel active on click

### DIFF
--- a/src/extension/commands/run_query_utils.ts
+++ b/src/extension/commands/run_query_utils.ts
@@ -200,6 +200,7 @@ https://github.com/malloydata/malloy-vscode-extension/issues.`;
                   name
                 );
               } else if (message.status === QueryRunStatus.RunCommand) {
+                MALLOY_EXTENSION_STATE.setActiveWebviewPanelId(panelId);
                 vscode.commands.executeCommand(
                   message.command,
                   ...message.args


### PR DESCRIPTION
We lose active panel status when running a query, bring it back when it gets clicked on.