### PR TITLE
Use new baseImportURL parameter

### DIFF
--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -24,32 +24,6 @@
 
 import * as vscode from 'vscode';
 import {CellData, FileHandler} from '../common/types';
-import {Utils} from 'vscode-uri';
-
-/**
- * Transforms vscode-notebook-cell: Uris to file: or vscode-vfs: URLS
- * based on the workspace, because VS Code can't use a vscode-notebook-cell:
- * as a relative url for non-cells, like external Malloy files.
- *
- * @param uri Document uri
- * @returns Uri with an appropriate protocol
- */
-const fixNotebookUri = (uri: vscode.Uri) => {
-  if (uri.scheme === 'vscode-notebook-cell') {
-    const {scheme} = vscode.workspace.workspaceFolders?.[0].uri || {
-      scheme: 'file:',
-    };
-    const {authority, path, query} = uri;
-    uri = vscode.Uri.from({
-      scheme,
-      authority,
-      path,
-      query,
-    });
-  }
-
-  return uri;
-};
 
 /**
  * Fetches the text contents of a Uri for the Malloy compiler. For most Uri
@@ -72,13 +46,13 @@ export async function fetchFile(uriString: string): Promise<string> {
   if (openDocument !== undefined) {
     return openDocument.getText();
   } else {
-    const contents = await vscode.workspace.fs.readFile(fixNotebookUri(uri));
+    const contents = await vscode.workspace.fs.readFile(uri);
     return new TextDecoder('utf-8').decode(contents);
   }
 }
 
 export async function fetchBinaryFile(uriString: string): Promise<Uint8Array> {
-  const uri = fixNotebookUri(vscode.Uri.parse(uriString));
+  const uri = vscode.Uri.parse(uriString);
   try {
     return await vscode.workspace.fs.readFile(uri);
   } catch (error) {
@@ -93,10 +67,11 @@ export async function fetchCellData(uriString: string): Promise<CellData> {
     notebook => notebook.uri.path === uri.path
   );
   const result: CellData = {
-    baseUri: Utils.dirname(fixNotebookUri(uri)).toString(),
+    baseUri: uriString,
     cells: [],
   };
   if (notebook) {
+    result.baseUri = notebook.uri.toString();
     for (const cell of notebook.getCells()) {
       if (cell.kind === vscode.NotebookCellKind.Code) {
         result.cells.push({

--- a/src/server/definitions/definitions.ts
+++ b/src/server/definitions/definitions.ts
@@ -25,24 +25,13 @@ import {Location, Position, DefinitionLink} from 'vscode-languageserver/node';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {TranslateCache} from '../translate_cache';
 
-const fixNotebookUri = (uriString: string, baseUriString: string) => {
-  const uri = new URL(uriString);
-  const baseUri = new URL(baseUriString);
-
-  if (uri.protocol === 'vscode-notebook-cell:' && !uri.hash) {
-    uriString = uriString.replace('vscode-notebook-cell:', baseUri.protocol);
-  }
-
-  return uriString;
-};
-
 export async function getMalloyDefinitionReference(
   translateCache: TranslateCache,
   document: TextDocument,
   position: Position
 ): Promise<Location[] | DefinitionLink[]> {
   try {
-    const {model, baseUri} = await translateCache.translateWithCache(
+    const model = await translateCache.translateWithCache(
       document.uri,
       document.version,
       document.languageId
@@ -55,7 +44,7 @@ export async function getMalloyDefinitionReference(
     if (location) {
       return [
         {
-          uri: fixNotebookUri(location.url, baseUri),
+          uri: location.url,
           range: location.range,
         },
       ];
@@ -69,7 +58,7 @@ export async function getMalloyDefinitionReference(
         return [
           {
             originSelectionRange: importLocation.location.range,
-            targetUri: fixNotebookUri(importLocation.importURL, baseUri),
+            targetUri: importLocation.importURL,
             targetRange: documentStart,
             targetSelectionRange: documentStart,
           },

--- a/src/server/diagnostics/diagnostics.ts
+++ b/src/server/diagnostics/diagnostics.ts
@@ -57,7 +57,7 @@ export async function getMalloyDiagnostics(
   }
 
   try {
-    const {model} = await translateCache.translateWithCache(
+    const model = await translateCache.translateWithCache(
       document.uri,
       document.version,
       document.languageId

--- a/src/server/translate_cache.ts
+++ b/src/server/translate_cache.ts
@@ -53,7 +53,7 @@ export class TranslateCache implements TranslateCache {
     {model: Model; exploreCount: number; version: number}
   >();
   truncatedVersion = 0;
-  cache = new Map<string, {model: Model; version: number; baseUri: string}>();
+  cache = new Map<string, {model: Model; version: number}>();
 
   constructor(
     private documents: TextDocuments<TextDocument>,
@@ -63,7 +63,7 @@ export class TranslateCache implements TranslateCache {
     connection.onRequest(
       'malloy/fetchModel',
       async (event: BuildModelRequest): Promise<FetchModelMessage> => {
-        const {model} = await this.translateWithCache(
+        const model = await this.translateWithCache(
           event.uri,
           event.version,
           event.languageId
@@ -105,27 +105,28 @@ export class TranslateCache implements TranslateCache {
   async createModelMaterializer(
     uri: string,
     runtime: Runtime
-  ): Promise<{modelMaterializer: ModelMaterializer | null; baseUri: string}> {
+  ): Promise<ModelMaterializer | null> {
     let modelMaterializer: ModelMaterializer | null = null;
-    let baseUri = uri;
     const queryFileURL = new URL(uri);
     if (queryFileURL.protocol === 'vscode-notebook-cell:') {
       const cellData = await this.getCellData(new URL(uri));
-      baseUri = cellData.baseUri;
+      const importBaseURL = new URL(cellData.baseUri);
       for (const cell of cellData.cells) {
         if (cell.languageId === 'malloy') {
           const url = new URL(cell.uri);
           if (modelMaterializer) {
-            modelMaterializer = modelMaterializer.extendModel(url);
+            modelMaterializer = modelMaterializer.extendModel(url, {
+              importBaseURL,
+            });
           } else {
-            modelMaterializer = runtime.loadModel(url);
+            modelMaterializer = runtime.loadModel(url, {importBaseURL});
           }
         }
       }
     } else {
       modelMaterializer = runtime.loadModel(queryFileURL);
     }
-    return {modelMaterializer, baseUri};
+    return modelMaterializer;
   }
 
   async getCellData(uri: URL): Promise<CellData> {
@@ -161,11 +162,11 @@ export class TranslateCache implements TranslateCache {
         files,
         this.connectionManager.getConnectionLookup(new URL(uri))
       );
-      const {modelMaterializer: mm} = await this.createModelMaterializer(
+      const modelMaterializer = await this.createModelMaterializer(
         uri,
         runtime
       );
-      const model = await mm?.getModel();
+      const model = await modelMaterializer?.getModel();
       if (model) {
         this.truncatedCache.set(uri, {
           model,
@@ -182,11 +183,11 @@ export class TranslateCache implements TranslateCache {
     uri: string,
     currentVersion: number,
     languageId: string
-  ): Promise<{model: Model | undefined; baseUri: string}> {
+  ): Promise<Model | undefined> {
     const entry = this.cache.get(uri);
     if (entry && entry.version === currentVersion) {
-      const {model, baseUri} = entry;
-      return {model, baseUri};
+      const {model} = entry;
+      return model;
     }
 
     const text = await this.getDocumentText(this.documents, new URL(uri));
@@ -200,7 +201,7 @@ export class TranslateCache implements TranslateCache {
         this.connectionManager.getConnectionLookup(new URL(uri))
       );
 
-      const {modelMaterializer, baseUri} = await this.createModelMaterializer(
+      const modelMaterializer = await this.createModelMaterializer(
         uri,
         runtime
       );
@@ -226,9 +227,9 @@ export class TranslateCache implements TranslateCache {
 
       const model = await modelMaterializer?.getModel();
       if (model) {
-        this.cache.set(uri, {version: currentVersion, model, baseUri});
+        this.cache.set(uri, {version: currentVersion, model});
       }
-      return {model, baseUri};
+      return model;
     } else if (languageId === 'malloy-notebook') {
       // TODO(whscullin): Delete with malloy-sql text editor
       const parse = MalloySQLParser.parse(text, uri);
@@ -244,22 +245,18 @@ export class TranslateCache implements TranslateCache {
           )}`;
       }
 
-      // TODO is there some way I can just say "here's some text, use this URI for relative imports"?
       const files = {
-        readURL: async (url: URL) => {
-          return url.toString() === uri
-            ? Promise.resolve(malloyStatements)
-            : this.getDocumentText(this.documents, url);
-        },
+        readURL: async (url: URL) => this.getDocumentText(this.documents, url),
       };
       const runtime = new Runtime(
         files,
         this.connectionManager.getConnectionLookup(new URL(uri))
       );
 
-      const mm = runtime.loadModel(new URL(uri));
+      const mm = runtime.loadModel(malloyStatements, {
+        importBaseURL: new URL(uri),
+      });
       const model = await mm.getModel();
-      const baseUri = uri;
 
       for (const statement of parse.statements.filter(
         (s): s is MalloySQLSQLStatement => s.type === MalloySQLStatementType.SQL
@@ -278,8 +275,8 @@ export class TranslateCache implements TranslateCache {
         }
       }
 
-      this.cache.set(uri, {version: currentVersion, model, baseUri});
-      return {model, baseUri};
+      this.cache.set(uri, {version: currentVersion, model});
+      return model;
     } else {
       const files = {
         readURL: (url: URL) => this.getDocumentText(this.documents, url),
@@ -289,15 +286,15 @@ export class TranslateCache implements TranslateCache {
         this.connectionManager.getConnectionLookup(new URL(uri))
       );
 
-      const {modelMaterializer, baseUri} = await this.createModelMaterializer(
+      const modelMaterializer = await this.createModelMaterializer(
         uri,
         runtime
       );
       const model = await modelMaterializer?.getModel();
       if (model) {
-        this.cache.set(uri, {version: currentVersion, model, baseUri});
+        this.cache.set(uri, {version: currentVersion, model});
       }
-      return {model, baseUri};
+      return model;
     }
   }
 }

--- a/src/worker/create_runnable.ts
+++ b/src/worker/create_runnable.ts
@@ -38,13 +38,14 @@ export const createModelMaterializer = async (
   let mm: ModelMaterializer | null = null;
   const queryFileURL = new URL(query.uri);
   if (cellData) {
+    const importBaseURL = new URL(cellData.baseUri);
     for (const cell of cellData.cells) {
       if (cell.languageId === 'malloy') {
         const url = new URL(cell.uri);
         if (mm) {
-          mm = mm.extendModel(url);
+          mm = mm.extendModel(url, {importBaseURL});
         } else {
-          mm = runtime.loadModel(url);
+          mm = runtime.loadModel(url, {importBaseURL});
         }
       }
     }


### PR DESCRIPTION
This removes to need to quietly swap out `vscode-notebook-cell:` URLs with `file:` URLs because we're not always in a position to do so, imports retain their correct import URLs from the filesystem. 