### PR TITLE
Remove the word 'experimental' from the descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "malloy-vscode",
   "publisher": "malloydata",
   "displayName": "Malloy",
-  "description": "Malloy is an experimental language for describing data relationships and transformations",
+  "description": "Malloy is an open source language for describing data relationships and transformations",
   "version": "0.2.0",
   "private": true,
   "config": {

--- a/src/extension/webviews/help_page/App.tsx
+++ b/src/extension/webviews/help_page/App.tsx
@@ -41,7 +41,7 @@ export const App: React.FC = () => {
       <Help>
         <h3 id="about-malloy">About Malloy</h3>
         <p>
-          Malloy is an experimental language for describing data relationships
+          Malloy is an open source language for describing data relationships
           and transformations. It is both a semantic modeling language and a
           querying language that runs queries against a relational database.
           Malloy currently supports BigQuery, Postgres, and DuckDB.


### PR DESCRIPTION
Shall we remove the word 'experimental' from all our READMEs and extension descriptions?