### PR TITLE
Don't use placeholder for renderer

### DIFF
--- a/src/extension/notebook/renderer/malloy_renderer.ts
+++ b/src/extension/notebook/renderer/malloy_renderer.ts
@@ -57,7 +57,7 @@ export class MalloyRenderer extends LitElement {
     const resultHtml = new HTMLView(document).render(result, {
       dataStyles: {},
     });
-    return html`${until(resultHtml, html`Rendering...`)}`;
+    return html`${until(resultHtml)}`;
   }
 }
 


### PR DESCRIPTION
VS Code was using the height of the placeholder instead of the eventual result. Not sure how to goose things so just not returning anything until we have a render.