### PR TITLE
Better indicate unsupported types

### DIFF
--- a/src/extension/webviews/components/icons.ts
+++ b/src/extension/webviews/components/icons.ts
@@ -694,3 +694,9 @@ export const viewContainerIcon = svg`
 export const chevronRightIcon = svg`<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px"><path d="M504-480 320-664l56-56 240 240-240 240-56-56 184-184Z"/></svg>`;
 
 export const chevronDownIcon = svg`<svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px"><path d="M480-345 240-585l56-56 184 184 184-184 56 56-240 240Z"/></svg>`;
+
+export const unknownIcon = svg`
+  <svg xmlns="http://www.w3.org/2000/svg" height="16px" viewBox="0 -960 960 960" width="16px">
+    <path d="M200-120q-33 0-56.5-23.5T120-200v-160h80v160h160v80H200Zm560 0H600v-80h160v-160h80v160q0 33-23.5 56.5T760-120ZM120-760q0-33 23.5-56.5T200-840h160v80H200v160h-80v-160Zm720 0v160h-80v-160H600v-80h160q33 0 56.5 23.5T840-760ZM480-240q21 0 35.5-14.5T530-290q0-21-14.5-35.5T480-340q-21 0-35.5 14.5T430-290q0 21 14.5 35.5T480-240Zm-36-153h73q0-34 8-52t35-45q35-35 46.5-56.5T618-598q0-54-39-88t-99-34q-50 0-86 26t-52 74l66 27q7-26 26.5-42.5T480-652q29 0 46.5 15.5T544-595q0 20-9.5 37.5T502-521q-33 29-45.5 56T444-393Z" />
+  </svg>
+`;

--- a/src/extension/webviews/components/schema_renderer.ts
+++ b/src/extension/webviews/components/schema_renderer.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {LitElement, html} from 'lit';
+import {LitElement, TemplateResult, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 
@@ -44,6 +44,7 @@ import {
   queryIcon,
   stringIcon,
   timeIcon,
+  unknownIcon,
 } from './icons';
 
 const sortByName = (a: {name: string}, b: {name: string}) =>
@@ -100,7 +101,7 @@ function bucketFields(fields: Field[]) {
  * @returns A React wrapped svg of the icon.
  */
 function getIconElement(fieldType: string, isAggregate: boolean) {
-  let imageElement;
+  let imageElement: TemplateResult | null;
   if (isAggregate) {
     imageElement = numberAggregateIcon;
   } else {
@@ -134,7 +135,7 @@ function getIconElement(fieldType: string, isAggregate: boolean) {
         imageElement = queryIcon;
         break;
       default:
-        imageElement = null;
+        imageElement = unknownIcon;
     }
   }
 
@@ -167,11 +168,14 @@ function buildTitle(field: Field | Explore, path: string) {
   if (field.isExplore()) {
     return field.name;
   }
-  const type = fieldType(field);
+  let typeLabel = fieldType(field);
+  if (field.isAtomicField() && field.isUnsupported()) {
+    typeLabel = `${typeLabel} (${field.rawType})`;
+  }
   const fieldName = field.name;
   return `${fieldName}
 Path: ${path}${path ? '.' : ''}${fieldName}
-Type: ${type}`;
+Type: ${typeLabel}`;
 }
 
 /**


### PR DESCRIPTION
Gives an icon and explanatory tooltip:

<img width="293" alt="Screenshot 2023-11-03 at 3 56 19 PM" src="https://github.com/malloydata/malloy-vscode-extension/assets/2958002/f37caf99-c2f6-4389-bc4b-4ae794aba4c1">
