### PR TITLE
Project Name -> Project ID

### DIFF
--- a/src/extension/webviews/connections_page/ConnectionEditor/BigQueryConnectionEditor/BigQueryConnectionEditor.tsx
+++ b/src/extension/webviews/connections_page/ConnectionEditor/BigQueryConnectionEditor/BigQueryConnectionEditor.tsx
@@ -54,7 +54,7 @@ export const BigQueryConnectionEditor: React.FC<
         </tr>
         <tr>
           <LabelCell>
-            <Label>Project Name:</Label>
+            <Label>Project ID:</Label>
           </LabelCell>
           <td>
             <TextField


### PR DESCRIPTION
We're actually asking for a Project ID here, project names are human readable and can have spaces and punctuation. I'd love to update the backing config variable, too, but this at least clears up the UI.