### PR TITLE
import http

### DIFF
--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -63,7 +63,11 @@ export async function fetchFile(uriString: string): Promise<string> {
   const openFiles = vscode.workspace.textDocuments;
   if (['http', 'https'].includes(uri.scheme)) {
     const response = await fetch(uriString);
-    return response.text();
+    if (response.status >= 200 && response.status < 300) {
+      return response.text();
+    } else {
+      throw new Error(`Unable to fetch ${uriString}: ${response.statusText}`);
+    }
   }
 
   const openDocument = openFiles.find(
@@ -83,9 +87,13 @@ export async function fetchBinaryFile(uriString: string): Promise<Uint8Array> {
   const uri = fixNotebookUri(vscode.Uri.parse(uriString));
   if (['http', 'https'].includes(uri.scheme)) {
     const response = await fetch(uriString);
-    const body = await response.blob();
-    const binary = await body.arrayBuffer();
-    return new Uint8Array(binary);
+    if (response.status >= 200 && response.status < 300) {
+      const body = await response.blob();
+      const binary = await body.arrayBuffer();
+      return new Uint8Array(binary);
+    } else {
+      throw new Error(`Unable to fetch ${uriString}: ${response.statusText}`);
+    }
   }
 
   try {

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -61,6 +61,10 @@ const fixNotebookUri = (uri: vscode.Uri) => {
 export async function fetchFile(uriString: string): Promise<string> {
   const uri = vscode.Uri.parse(uriString);
   const openFiles = vscode.workspace.textDocuments;
+  if (['http', 'https'].includes(uri.scheme)) {
+    const response = await fetch(uriString);
+    return response.text();
+  }
 
   const openDocument = openFiles.find(
     document => document.uri.toString() === uriString
@@ -77,6 +81,13 @@ export async function fetchFile(uriString: string): Promise<string> {
 
 export async function fetchBinaryFile(uriString: string): Promise<Uint8Array> {
   const uri = fixNotebookUri(vscode.Uri.parse(uriString));
+  if (['http', 'https'].includes(uri.scheme)) {
+    const response = await fetch(uriString);
+    const body = await response.blob();
+    const binary = await body.arrayBuffer();
+    return new Uint8Array(binary);
+  }
+
   try {
     return await vscode.workspace.fs.readFile(uri);
   } catch (error) {


### PR DESCRIPTION
Add support for http urls, like
```
import "https://raw.githubusercontent.com/malloydata/malloy-samples/main/faa/flights.malloy"
```
Note this will have limited support in browser versions of the extension because of CORS.