### PR TITLE
Remove extraneous node references.

### DIFF
--- a/src/server/completions/completions.ts
+++ b/src/server/completions/completions.ts
@@ -26,7 +26,7 @@ import {
   CompletionItem,
   CompletionItemKind,
   MarkupKind,
-} from 'vscode-languageserver/node';
+} from 'vscode-languageserver';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {COMPLETION_DOCS} from '../../common/completion_docs';
 import {parseWithCache} from '../parse_cache';

--- a/src/server/completions/schema_completions.ts
+++ b/src/server/completions/schema_completions.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {CompletionParams} from 'vscode-languageserver/node';
+import {CompletionParams} from 'vscode-languageserver';
 import {Position, TextDocument} from 'vscode-languageserver-textdocument';
 import {TranslateCache} from '../translate_cache';
 import {Explore, Field, Model} from '@malloydata/malloy';

--- a/src/server/definitions/definitions.ts
+++ b/src/server/definitions/definitions.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {Location, Position, DefinitionLink} from 'vscode-languageserver/node';
+import {Location, Position, DefinitionLink} from 'vscode-languageserver';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {TranslateCache} from '../translate_cache';
 

--- a/src/server/highlights/highlights.ts
+++ b/src/server/highlights/highlights.ts
@@ -23,10 +23,7 @@
 
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {HighlightType} from '@malloydata/malloy';
-import {
-  SemanticTokens,
-  SemanticTokensBuilder,
-} from 'vscode-languageserver/node';
+import {SemanticTokens, SemanticTokensBuilder} from 'vscode-languageserver';
 import {parseWithCache} from '../parse_cache';
 
 export const TOKEN_TYPES = [

--- a/src/server/hover/hover.ts
+++ b/src/server/hover/hover.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {Hover, HoverParams, MarkupKind} from 'vscode-languageserver/node';
+import {Hover, HoverParams, MarkupKind} from 'vscode-languageserver';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 
 import {COMPLETION_DOCS} from '../../common/completion_docs';

--- a/src/server/lenses/lenses.ts
+++ b/src/server/lenses/lenses.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {CodeLens, Position, Range} from 'vscode-languageserver/node';
+import {CodeLens, Position, Range} from 'vscode-languageserver';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {parseWithCache} from '../parse_cache';
 

--- a/src/server/node/server_node.ts
+++ b/src/server/node/server_node.ts
@@ -24,7 +24,7 @@
 import {
   DidChangeConfigurationParams,
   TextDocuments,
-} from 'vscode-languageserver/node';
+} from 'vscode-languageserver';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {connection, connectionManager} from './connections_node';
 import {initServer} from '../init';

--- a/src/server/symbols/symbols.ts
+++ b/src/server/symbols/symbols.ts
@@ -23,7 +23,7 @@
 
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {DocumentSymbol as MalloyDocumentSymbol} from '@malloydata/malloy';
-import {DocumentSymbol, SymbolKind} from 'vscode-languageserver/node';
+import {DocumentSymbol, SymbolKind} from 'vscode-languageserver';
 import {parseWithCache} from '../parse_cache';
 
 function mapSymbol({


### PR DESCRIPTION
The language server is generally platform neutral, importing types from `vscode-languageserver` isntead of `vscode-languageserver/node`