### PR TITLE
Simplify TextDocument/QuerySpec usage

### DIFF
--- a/src/common/query_spec.ts
+++ b/src/common/query_spec.ts
@@ -20,36 +20,42 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-import * as vscode from 'vscode';
+
+export interface DocumentMetadata {
+  fileName: string;
+  uri: string;
+  languageId: string;
+  version: number;
+}
 
 export interface NamedQuerySpec {
   type: 'named';
   name: string;
-  file: vscode.TextDocument;
+  documentMeta: DocumentMetadata;
 }
 
 export interface QueryStringSpec {
   type: 'string';
   text: string;
-  file: vscode.TextDocument;
+  documentMeta: DocumentMetadata;
 }
 
 export interface QueryFileSpec {
   type: 'file';
   index: number;
-  file: vscode.TextDocument;
+  documentMeta: DocumentMetadata;
 }
 
 export interface NamedSQLQuerySpec {
   type: 'named_sql';
   name: string;
-  file: vscode.TextDocument;
+  documentMeta: DocumentMetadata;
 }
 
 export interface UnnamedSQLQuerySpec {
   type: 'unnamed_sql';
   index: number;
-  file: vscode.TextDocument;
+  documentMeta: DocumentMetadata;
 }
 
 export type QuerySpec =

--- a/src/common/worker_message_types.ts
+++ b/src/common/worker_message_types.ts
@@ -30,43 +30,7 @@ import {
 } from 'vscode-jsonrpc';
 import {QueryDownloadOptions} from './message_types';
 import {CellData, MalloyConfig} from './types';
-
-interface NamedQuerySpec {
-  type: 'named';
-  name: string;
-  uri: string;
-}
-
-interface QueryStringSpec {
-  type: 'string';
-  text: string;
-  uri: string;
-}
-
-interface QueryFileSpec {
-  type: 'file';
-  index: number;
-  uri: string;
-}
-
-interface NamedSQLQuerySpec {
-  type: 'named_sql';
-  name: string;
-  uri: string;
-}
-
-interface UnnamedSQLQuerySpec {
-  type: 'unnamed_sql';
-  index: number;
-  uri: string;
-}
-
-export type WorkerQuerySpec =
-  | NamedQuerySpec
-  | QueryStringSpec
-  | QueryFileSpec
-  | NamedSQLQuerySpec
-  | UnnamedSQLQuerySpec;
+import {QuerySpec} from './query_spec';
 
 /*
  * Incoming messages
@@ -76,7 +40,7 @@ export type WorkerQuerySpec =
 export interface MessageExit {}
 
 export interface MessageRun {
-  query: WorkerQuerySpec;
+  query: QuerySpec;
   panelId: string;
   name: string;
   showSQLOnly: boolean;
@@ -124,7 +88,7 @@ export interface MessageFetchCellData {
 }
 
 export interface MessageDownload {
-  query: WorkerQuerySpec;
+  query: QuerySpec;
   panelId: string;
   name: string;
   uri: string;

--- a/src/extension/commands/query_download.ts
+++ b/src/extension/commands/query_download.ts
@@ -26,11 +26,10 @@ import {QueryDownloadOptions} from '../../common/message_types';
 
 import * as vscode from 'vscode';
 import {Utils} from 'vscode-uri';
-import {QuerySpec} from './query_spec';
+import {QuerySpec} from '../../common/query_spec';
 import {
   MessageDownload,
   WorkerDownloadMessage,
-  WorkerQuerySpec,
 } from '../../common/worker_message_types';
 import {MALLOY_EXTENSION_STATE} from '../state';
 import {Disposable} from 'vscode-jsonrpc';
@@ -64,7 +63,7 @@ class VSCodeWriteStream implements WriteStream {
 
 const sendDownloadMessage = (
   worker: WorkerConnection,
-  query: WorkerQuerySpec,
+  query: QuerySpec,
   panelId: string,
   name: string,
   uri: string,
@@ -147,13 +146,9 @@ export async function queryDownload(
               )
             );
           } else {
-            const {file, ...params} = query;
             sendDownloadMessage(
               worker,
-              {
-                uri: file.uri.toString(),
-                ...params,
-              },
+              query,
               panelId,
               name,
               fileUri.toString(),

--- a/src/extension/commands/run_named_query.ts
+++ b/src/extension/commands/run_named_query.ts
@@ -21,24 +21,23 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as vscode from 'vscode';
-import {MALLOY_EXTENSION_STATE} from '../state';
 import {WorkerConnection} from '../worker_connection';
-import {runMalloyQueryWithProgress} from './run_query_utils';
+import {
+  getActiveDocumentMetadata,
+  runMalloyQueryWithProgress,
+} from './run_query_utils';
 import {ResultJSON} from '@malloydata/malloy';
 
 export async function runNamedQuery(
   worker: WorkerConnection,
   name: string
 ): Promise<ResultJSON | undefined> {
-  const document =
-    vscode.window.activeTextEditor?.document ||
-    MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;
-  if (document) {
+  const documentMeta = getActiveDocumentMetadata();
+  if (documentMeta) {
     return runMalloyQueryWithProgress(
       worker,
-      {type: 'named', name, file: document},
-      `${document.uri.toString()} ${name}`,
+      {type: 'named', name, documentMeta},
+      `${documentMeta.uri} ${name}`,
       name
     );
   }

--- a/src/extension/commands/run_named_sql_block.ts
+++ b/src/extension/commands/run_named_sql_block.ts
@@ -21,20 +21,19 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as vscode from 'vscode';
-import {MALLOY_EXTENSION_STATE} from '../state';
 import {WorkerConnection} from '../worker_connection';
-import {runMalloyQueryWithProgress} from './run_query_utils';
+import {
+  getActiveDocumentMetadata,
+  runMalloyQueryWithProgress,
+} from './run_query_utils';
 
 export function runNamedSQLBlock(worker: WorkerConnection, name: string): void {
-  const document =
-    vscode.window.activeTextEditor?.document ||
-    MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;
-  if (document) {
+  const documentMeta = getActiveDocumentMetadata();
+  if (documentMeta) {
     runMalloyQueryWithProgress(
       worker,
-      {type: 'named_sql', name, file: document},
-      `${document.uri.toString()} ${name}`,
+      {type: 'named_sql', name, documentMeta},
+      `${documentMeta.uri} ${name}`,
       name
     );
   }

--- a/src/extension/commands/run_query.ts
+++ b/src/extension/commands/run_query.ts
@@ -21,10 +21,11 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as vscode from 'vscode';
-import {MALLOY_EXTENSION_STATE} from '../state';
 import {WorkerConnection} from '../worker_connection';
-import {runMalloyQueryWithProgress} from './run_query_utils';
+import {
+  getActiveDocumentMetadata,
+  runMalloyQueryWithProgress,
+} from './run_query_utils';
 import {ResultJSON} from '@malloydata/malloy';
 
 export async function runQueryCommand(
@@ -33,15 +34,13 @@ export async function runQueryCommand(
   name?: string,
   defaultTab?: string
 ): Promise<ResultJSON | undefined> {
-  const document =
-    vscode.window.activeTextEditor?.document ||
-    MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;
-  if (document) {
+  const documentMeta = getActiveDocumentMetadata();
+  if (documentMeta) {
     return runMalloyQueryWithProgress(
       worker,
-      {type: 'string', text: query, file: document},
-      `${document.uri.toString()} ${name}`,
-      name || document.uri.toString(),
+      {type: 'string', text: query, documentMeta},
+      `${documentMeta.uri} ${name}`,
+      name || documentMeta.uri,
       {defaultTab}
     );
   }

--- a/src/extension/commands/run_query_at_cursor.ts
+++ b/src/extension/commands/run_query_at_cursor.ts
@@ -24,7 +24,6 @@
 import * as vscode from 'vscode';
 import {MALLOY_EXTENSION_STATE} from '../state';
 import {WorkerConnection} from '../worker_connection';
-// import {runMalloyQueryWithProgress} from './run_query_utils';
 import {ResultJSON} from '@malloydata/malloy';
 import {BaseLanguageClient, CodeLens} from 'vscode-languageclient';
 

--- a/src/extension/commands/run_query_file.ts
+++ b/src/extension/commands/run_query_file.ts
@@ -21,8 +21,10 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as vscode from 'vscode';
-import {runMalloyQueryWithProgress} from './run_query_utils';
+import {
+  runMalloyQueryWithProgress,
+  getActiveDocumentMetadata,
+} from './run_query_utils';
 import {WorkerConnection} from '../worker_connection';
 import {ResultJSON} from '@malloydata/malloy';
 
@@ -30,13 +32,17 @@ export async function runQueryFileCommand(
   worker: WorkerConnection,
   queryIndex = -1
 ): Promise<ResultJSON | undefined> {
-  const document = vscode.window.activeTextEditor?.document;
-  if (document) {
+  const documentMeta = getActiveDocumentMetadata();
+  if (documentMeta) {
     return runMalloyQueryWithProgress(
       worker,
-      {type: 'file', index: queryIndex, file: document},
-      document.uri.toString(),
-      document.fileName.split('/').pop() || document.fileName
+      {
+        type: 'file',
+        index: queryIndex,
+        documentMeta,
+      },
+      documentMeta.uri,
+      documentMeta.fileName.split('/').pop() || documentMeta.fileName
     );
   }
 

--- a/src/extension/commands/run_unnamed_sql_block.ts
+++ b/src/extension/commands/run_unnamed_sql_block.ts
@@ -21,25 +21,24 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as vscode from 'vscode';
-import {MALLOY_EXTENSION_STATE} from '../state';
 import {WorkerConnection} from '../worker_connection';
-import {runMalloyQueryWithProgress} from './run_query_utils';
+import {
+  getActiveDocumentMetadata,
+  runMalloyQueryWithProgress,
+} from './run_query_utils';
 import {ResultJSON} from '@malloydata/malloy';
 
 export async function runUnnamedSQLBlock(
   worker: WorkerConnection,
   index: number
 ): Promise<ResultJSON | undefined> {
-  const document =
-    vscode.window.activeTextEditor?.document ||
-    MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;
-  if (document) {
+  const documentMeta = getActiveDocumentMetadata();
+  if (documentMeta) {
     return runMalloyQueryWithProgress(
       worker,
-      {type: 'unnamed_sql', index, file: document},
-      document.uri.toString(),
-      document.fileName.split('/').pop() || document.fileName
+      {type: 'unnamed_sql', index, documentMeta},
+      documentMeta.uri,
+      documentMeta.fileName.split('/').pop() || documentMeta.fileName
     );
   }
 

--- a/src/extension/commands/show_sql.ts
+++ b/src/extension/commands/show_sql.ts
@@ -21,25 +21,24 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as vscode from 'vscode';
-import {MALLOY_EXTENSION_STATE} from '../state';
 import {WorkerConnection} from '../worker_connection';
-import {runMalloyQueryWithProgress} from './run_query_utils';
+import {
+  getActiveDocumentMetadata,
+  runMalloyQueryWithProgress,
+} from './run_query_utils';
 
 export function showSQLCommand(
   worker: WorkerConnection,
   query: string,
   name?: string
 ): void {
-  const document =
-    vscode.window.activeTextEditor?.document ||
-    MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;
-  if (document) {
+  const documentMeta = getActiveDocumentMetadata();
+  if (documentMeta) {
     runMalloyQueryWithProgress(
       worker,
-      {type: 'string', text: query, file: document},
-      `${document.uri.toString()} ${name}`,
-      name || document.uri.toString(),
+      {type: 'string', text: query, documentMeta},
+      `${documentMeta.uri} ${name}`,
+      name || documentMeta.uri,
       {showSQLOnly: true}
     );
   }

--- a/src/extension/commands/show_sql_file.ts
+++ b/src/extension/commands/show_sql_file.ts
@@ -21,21 +21,23 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as vscode from 'vscode';
 import {WorkerConnection} from '../worker_connection';
-import {runMalloyQueryWithProgress} from './run_query_utils';
+import {
+  getActiveDocumentMetadata,
+  runMalloyQueryWithProgress,
+} from './run_query_utils';
 
 export function showSQLFileCommand(
   worker: WorkerConnection,
   queryIndex = -1
 ): void {
-  const document = vscode.window.activeTextEditor?.document;
-  if (document) {
+  const documentMeta = getActiveDocumentMetadata();
+  if (documentMeta) {
     runMalloyQueryWithProgress(
       worker,
-      {type: 'file', index: queryIndex, file: document},
-      document.uri.toString(),
-      document.fileName.split('/').pop() || document.fileName,
+      {type: 'file', index: queryIndex, documentMeta},
+      documentMeta.uri,
+      documentMeta.fileName.split('/').pop() || documentMeta.fileName,
       {showSQLOnly: true}
     );
   }

--- a/src/extension/commands/show_sql_named_query.ts
+++ b/src/extension/commands/show_sql_named_query.ts
@@ -21,23 +21,22 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as vscode from 'vscode';
-import {MALLOY_EXTENSION_STATE} from '../state';
 import {WorkerConnection} from '../worker_connection';
-import {runMalloyQueryWithProgress} from './run_query_utils';
+import {
+  getActiveDocumentMetadata,
+  runMalloyQueryWithProgress,
+} from './run_query_utils';
 
 export function showSQLNamedQueryCommand(
   worker: WorkerConnection,
   name: string
 ): void {
-  const document =
-    vscode.window.activeTextEditor?.document ||
-    MALLOY_EXTENSION_STATE.getActiveWebviewPanel()?.document;
-  if (document) {
+  const documentMeta = getActiveDocumentMetadata();
+  if (documentMeta) {
     runMalloyQueryWithProgress(
       worker,
-      {type: 'named', name, file: document},
-      `${document.uri.toString()} ${name}`,
+      {type: 'named', name, documentMeta},
+      `${documentMeta.uri} ${name}`,
       name,
       {showSQLOnly: true}
     );

--- a/src/extension/commands/vscode_utils.ts
+++ b/src/extension/commands/vscode_utils.ts
@@ -27,13 +27,14 @@ import {RunState, MALLOY_EXTENSION_STATE} from '../state';
 import {WebviewMessageManager} from '../webview_message_manager';
 import {getWebviewHtml} from '../webviews';
 import turtleIcon from '../../media/turtle.svg';
+import {DocumentMetadata} from '../../common/query_spec';
 
 export function createOrReuseWebviewPanel(
   viewType: string,
   title: string,
   panelId: string,
   cancel: () => void,
-  document: vscode.TextDocument
+  document: DocumentMetadata
 ): RunState {
   const previous = MALLOY_EXTENSION_STATE.getRunState(panelId);
 

--- a/src/extension/state.ts
+++ b/src/extension/state.ts
@@ -21,17 +21,18 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import vscode, {TextDocument, WebviewPanel} from 'vscode';
+import vscode, {WebviewPanel} from 'vscode';
 import {QueryMessageStatus} from '../common/message_types';
 import {WebviewMessageManager} from './webview_message_manager';
 import {Position} from 'vscode-languageclient';
+import {DocumentMetadata} from '../common/query_spec';
 
 export interface RunState {
   cancel: () => void;
   panel: WebviewPanel;
   messages: WebviewMessageManager<QueryMessageStatus>;
   panelId: string;
-  document: TextDocument;
+  document: DocumentMetadata;
 }
 
 class MalloyExtensionState {

--- a/src/worker/create_runnable.ts
+++ b/src/worker/create_runnable.ts
@@ -27,8 +27,8 @@ import {
   Runtime,
   SQLBlockMaterializer,
 } from '@malloydata/malloy';
-import {WorkerQuerySpec} from '../common/worker_message_types';
 import {CellData} from '../common/types';
+import {QuerySpec} from '../common/query_spec';
 
 export const createModelMaterializer = async (
   uri: string,
@@ -70,15 +70,18 @@ export const createModelMaterializer = async (
 };
 
 export const createRunnable = async (
-  query: WorkerQuerySpec,
+  query: QuerySpec,
   runtime: Runtime,
   cellData: CellData | null,
   workspaceFolders: string[]
 ): Promise<SQLBlockMaterializer | QueryMaterializer> => {
-  console.debug('createRunnable', query.uri, 'begin');
+  const {
+    documentMeta: {uri},
+  } = query;
+  console.debug('createRunnable', uri, 'begin');
   let runnable: QueryMaterializer | SQLBlockMaterializer;
   const mm = await createModelMaterializer(
-    query.uri,
+    uri,
     runtime,
     cellData,
     workspaceFolders
@@ -109,6 +112,6 @@ export const createRunnable = async (
     default:
       throw new Error('Internal Error: Unexpected query type');
   }
-  console.debug('createRunnable', query.uri, 'end');
+  console.debug('createRunnable', uri, 'end');
   return runnable;
 };

--- a/src/worker/node/download_query.ts
+++ b/src/worker/node/download_query.ts
@@ -49,10 +49,13 @@ const sendMessage = (
 export async function downloadQuery(
   messageHandler: WorkerMessageHandler,
   connectionManager: ConnectionManager,
-  {query, panelId, downloadOptions, name, uri}: MessageDownload,
+  {query, downloadOptions, name}: MessageDownload,
   fileHandler: FileHandler
 ): Promise<void> {
-  const url = new URL(panelId);
+  const {
+    documentMeta: {uri},
+  } = query;
+  const url = new URL(uri);
 
   try {
     const runtime = new Runtime(
@@ -61,12 +64,12 @@ export async function downloadQuery(
     );
 
     let cellData: CellData | null = null;
-    if (query.uri.startsWith('vscode-notebook-cell:')) {
-      cellData = await fileHandler.fetchCellData(query.uri);
+    if (uri.startsWith('vscode-notebook-cell:')) {
+      cellData = await fileHandler.fetchCellData(uri);
     }
     let workspaceFolders: string[] = [];
-    if (query.uri.startsWith('untitled:')) {
-      workspaceFolders = await fileHandler.fetchWorkspaceFolders(query.uri);
+    if (uri.startsWith('untitled:')) {
+      workspaceFolders = await fileHandler.fetchWorkspaceFolders(uri);
     }
     const runnable = await createRunnable(
       query,


### PR DESCRIPTION
Replace most uses of TextDocument with DocumentMetadata. This allows for un-opened documents to be used in places that currently only open documents can be used.