### PR TITLE
Add context menus to schema webview.

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,23 +145,23 @@
       },
       {
         "command": "malloy.runTurtleFromSchema",
-        "title": "Run From Schema",
+        "title": "Run",
         "category": "Malloy",
         "icon": "$(play)",
-        "enablement": "view == malloySchema && viewItem == query"
+        "enablement": "(view == malloySchema && viewItem == query) || (webviewId == malloyQuery && webviewSection == schemaQuery)"
       },
       {
         "command": "malloy.copyFieldPath",
         "title": "Copy Field Path",
         "category": "Malloy",
         "icon": "$(copy)",
-        "enablement": "view == malloySchema"
+        "enablement": "view == malloySchema || webviewId == malloyQuery"
       },
       {
         "command": "malloy.goToDefinitionFromSchema",
         "title": "Go to Definition",
         "category": "Malloy",
-        "enablement": "view == malloySchema"
+        "enablement": "view == malloySchema || webviewId == malloyQuery"
       },
       {
         "command": "malloy.previewFromSchema",
@@ -238,6 +238,20 @@
         {
           "command": "malloy.newUntitledNotebook",
           "group": "notebook"
+        }
+      ],
+      "webview/context": [
+        {
+          "command": "malloy.goToDefinitionFromSchema",
+          "when": "webviewId == malloyQuery && (webviewSection == schemaField || webviewSection == schemaQuery)"
+        },
+        {
+          "command": "malloy.runTurtleFromSchema",
+          "when": "webviewId == malloyQuery && webviewSection == schemaQuery"
+        },
+        {
+          "command": "malloy.copyFieldPath",
+          "when": "webviewId == malloyQuery && (webviewSection == schemaField || webviewSection == schemaQuery)"
         }
       ]
     },

--- a/src/extension/tree_views/schema_view.ts
+++ b/src/extension/tree_views/schema_view.ts
@@ -287,9 +287,10 @@ function getIconPath(
   return Utils.joinPath(uri, 'dist', imageFileName);
 }
 
-export function runTurtleFromSchemaCommand(
-  item: FieldItem | ExploreItem
-): void {
+export function runTurtleFromSchemaCommand(item: {
+  topLevelExplore: string;
+  accessPath: string[];
+}): void {
   vscode.commands.executeCommand(
     'malloy.runQuery',
     `run: ${item.topLevelExplore}->${item.accessPath.join('.')}`,
@@ -297,20 +298,23 @@ export function runTurtleFromSchemaCommand(
   );
 }
 
-export function previewFromSchemaCommand(item: FieldItem | ExploreItem): void {
+export function previewFromSchemaCommand(item: {
+  topLevelExplore: string;
+  accessPath: string[];
+}): void {
   vscode.commands.executeCommand(
     'malloy.runQuery',
     `run: ${item.topLevelExplore}->{ select: ${[...item.accessPath, '*'].join(
       '.'
     )}; limit: 20 }`,
-    `preview ${item.topLevelExplore} ${item.accessPath.join('.')}`,
+    `Preview ${item.topLevelExplore} ${item.accessPath.join('.')}`,
     'html'
   );
 }
 
-export function goToDefinitionFromSchemaCommand(
-  item: FieldItem | ExploreItem
-): void {
+export function goToDefinitionFromSchemaCommand(item: {
+  location?: DocumentLocation;
+}): void {
   const location = item.location;
   if (location) {
     const pos = new vscode.Position(

--- a/src/extension/webviews/components/schema_renderer.css
+++ b/src/extension/webviews/components/schema_renderer.css
@@ -79,6 +79,7 @@ li.fields label {
 
 .field_name {
   padding-left: 0.5em;
+  user-select: none;
 }
 
 svg {

--- a/src/extension/webviews/query_page/App.tsx
+++ b/src/extension/webviews/query_page/App.tsx
@@ -103,6 +103,7 @@ export const App: React.FC = () => {
     visible: tooltipVisible,
     placement: 'top',
   });
+  const ref = useRef<HTMLDivElement>(null);
 
   const vscode = useQueryVSCodeContext();
 
@@ -302,6 +303,30 @@ export const App: React.FC = () => {
     }
   };
 
+  /*
+   * Intercept the context menu click from the schema renderer, and
+   * apply context data to the element's `vscode-context` attribute.
+   * Then simulate a context click so that VS Code will pick up
+   * the context and draw a context menu.
+   */
+  const onContextClick = (
+    event: MouseEvent,
+    context: Record<string, unknown>
+  ) => {
+    event.stopPropagation();
+    context = {...context, preventDefaultContextMenuItems: true};
+    if (ref.current) {
+      ref.current.dataset['vscodeContext'] = JSON.stringify(context);
+    }
+    ref.current?.dispatchEvent(
+      new MouseEvent('contextmenu', {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        bubbles: true,
+      })
+    );
+  };
+
   return (
     <div
       style={{
@@ -310,6 +335,7 @@ export const App: React.FC = () => {
         display: 'flex',
         flexDirection: 'column',
       }}
+      ref={ref}
     >
       {[
         Status.Compiling,
@@ -405,6 +431,7 @@ export const App: React.FC = () => {
             defaultShow={true}
             onFieldClick={onFieldClick}
             onQueryClick={onQueryClick}
+            onContextClick={onContextClick}
           />
         </Scroll>
       )}


### PR DESCRIPTION
Use `vscode-context` to provide data to VS Code to bring up context menus in the Schema web view. Make method signatures match passed in values.