### PR TITLE
centralize malloy config read to provide location for key name migrat…

### DIFF
--- a/src/extension/commands/query_download.ts
+++ b/src/extension/commands/query_download.ts
@@ -38,6 +38,7 @@ import {Disposable} from 'vscode-jsonrpc';
 import {WorkerConnection} from '../worker_connection';
 import {errorMessage} from '../../common/errors';
 import {noAwait} from '../../util/no_await';
+import {getMalloyConfig} from '../utils';
 
 /**
  * VSCode doesn't support streaming writes, so fake it.
@@ -89,9 +90,7 @@ export async function queryDownload(
   panelId: string,
   name: string
 ): Promise<void> {
-  const configDownloadPath = vscode.workspace
-    .getConfiguration('malloy')
-    .get('downloadsPath');
+  const configDownloadPath = getMalloyConfig().get('downloadsPath');
   let downloadPath =
     configDownloadPath && typeof configDownloadPath === 'string'
       ? configDownloadPath

--- a/src/extension/connection_editor.ts
+++ b/src/extension/connection_editor.ts
@@ -36,6 +36,7 @@ import {ConnectionConfig} from '../common/connection_manager_types';
 import {MALLOY_EXTENSION_STATE} from './state';
 import {errorMessage} from '../common/errors';
 import {ConnectionManager} from '../common/connection_manager';
+import {getMalloyConfig} from './utils';
 
 export class EditConnectionPanel {
   panel: vscode.WebviewPanel;
@@ -79,7 +80,7 @@ export class EditConnectionPanel {
           const connections = await handleConnectionsPreSave(
             message.connections
           );
-          const malloyConfig = vscode.workspace.getConfiguration('malloy');
+          const malloyConfig = getMalloyConfig();
           const hasWorkspaceConfig =
             malloyConfig.inspect('connections')?.workspaceValue !== undefined;
           malloyConfig.update(

--- a/src/extension/connection_manager.ts
+++ b/src/extension/connection_manager.ts
@@ -21,17 +21,15 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import * as vscode from 'vscode';
 import {ConnectionManager} from '../common/connection_manager';
 import {ConnectionConfig} from '../common/connection_manager_types';
 import {ConnectionFactory} from '../common/connections/types';
+import {getMalloyConfig} from './utils';
 
 const DEFAULT_ROW_LIMIT = 50;
 
 const getConnectionsConfig = (): ConnectionConfig[] => {
-  return vscode.workspace
-    .getConfiguration('malloy')
-    .get('connections') as ConnectionConfig[];
+  return getMalloyConfig().get('connections') as ConnectionConfig[];
 };
 
 export class VSCodeConnectionManager extends ConnectionManager {
@@ -48,9 +46,7 @@ export class VSCodeConnectionManager extends ConnectionManager {
     // because the Language Server doesn't actually care about row limits, because it never
     // runs queries, and because it's slightly harder to get settings from within the language
     // server.
-    const rowLimitRaw = vscode.workspace
-      .getConfiguration('malloy')
-      .get('rowLimit');
+    const rowLimitRaw = getMalloyConfig().get('rowLimit');
     if (rowLimitRaw === undefined) {
       return DEFAULT_ROW_LIMIT;
     }

--- a/src/extension/node/extension_node.ts
+++ b/src/extension/node/extension_node.ts
@@ -34,7 +34,7 @@ import {editConnectionsCommand} from './commands/edit_connections';
 import {ConnectionsProvider} from '../tree_views/connections_view';
 import {connectionManager} from './connection_manager';
 import {setupFileMessaging, setupSubscriptions} from '../subscriptions';
-import {fileHandler} from '../utils';
+import {fileHandler, getMalloyConfig} from '../utils';
 import {MALLOY_EXTENSION_STATE} from '../state';
 import {WorkerConnectionNode} from './worker_connection_node';
 import {MalloyConfig} from '../../common/types';
@@ -146,9 +146,7 @@ async function setupLanguageServer(
 
 function sendWorkerConfig(worker: WorkerConnectionNode) {
   worker.sendRequest('malloy/config', {
-    malloy: vscode.workspace.getConfiguration(
-      'malloy'
-    ) as unknown as MalloyConfig,
+    malloy: getMalloyConfig() as unknown as MalloyConfig,
     cloudcode: vscode.workspace.getConfiguration(
       'cloudcode'
     ) as unknown as CloudCodeConfig,

--- a/src/extension/telemetry.ts
+++ b/src/extension/telemetry.ts
@@ -24,13 +24,13 @@
 import * as vscode from 'vscode';
 import {MALLOY_EXTENSION_STATE} from './state';
 import fetch from 'node-fetch';
+import {getMalloyConfig} from './utils';
 
 const telemetryLog = vscode.window.createOutputChannel('Malloy Telemetry');
 
 function isTelemetryEnabled() {
   const vsCodeValue = vscode.env.isTelemetryEnabled;
-  const configValue =
-    vscode.workspace.getConfiguration('malloy').get('telemetry') ?? false;
+  const configValue = getMalloyConfig().get('telemetry') ?? false;
   return vsCodeValue && configValue;
 }
 

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -50,6 +50,16 @@ const fixNotebookUri = (uri: vscode.Uri) => {
 };
 
 /**
+ * Centralized place to pull configuration for Malloy extension
+ *
+ * @returns Uri with an appropriate protocol
+ */
+export const getMalloyConfig = (): vscode.WorkspaceConfiguration => {
+  const malloyConfig = vscode.workspace.getConfiguration('malloy');
+  return malloyConfig;
+};
+
+/**
  * Fetches the text contents of a Uri for the Malloy compiler. For most Uri
  * types this means either from the open file cache, or from VS Code's
  * file system.

--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -52,7 +52,7 @@ const fixNotebookUri = (uri: vscode.Uri) => {
 /**
  * Centralized place to pull configuration for Malloy extension
  *
- * @returns Uri with an appropriate protocol
+ * @returns Malloy config (vscode.WorkspaceConfiguration)
  */
 export const getMalloyConfig = (): vscode.WorkspaceConfiguration => {
   const malloyConfig = vscode.workspace.getConfiguration('malloy');


### PR DESCRIPTION
…ion (want to move key name malloy["connections"][{{any bigquery connection}}]["projectName"] to "projectId").

This has the added benefit of providing centralized place to do...anything else with config, instead of reading "malloy" config from variety of places