### PR TITLE
Support context menu in notebook schema view

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,19 +250,23 @@
       "webview/context": [
         {
           "command": "malloy.goToDefinitionFromSchema",
-          "when": " webviewSection == malloySchemaField || webviewSection == malloySchemaNamedQuery || webviewSection == malloySchemaQuery"
+          "when": "webviewSection == malloySchemaField || webviewSection == malloySchemaNamedQuery || webviewSection == malloySchemaQuery",
+          "group": "schema@2"
         },
         {
           "command": "malloy.runTurtleFromSchema",
-          "when": "webviewSection == malloySchemaQuery"
+          "when": "webviewSection == malloySchemaQuery",
+          "group": "schema@1"
         },
         {
           "command": "malloy.runNamedQueryFromSchema",
-          "when": "webviewSection == malloySchemaNamedQuery"
+          "when": "webviewSection == malloySchemaNamedQuery",
+          "group": "schema@1"
         },
         {
           "command": "malloy.copyFieldPath",
-          "when": "webviewSection == malloySchemaField || webviewSection == malloySchemaQuery"
+          "when": "webviewSection == malloySchemaField || webviewSection == malloySchemaQuery",
+          "group": "schema@3"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -148,20 +148,27 @@
         "title": "Run",
         "category": "Malloy",
         "icon": "$(play)",
-        "enablement": "(view == malloySchema && viewItem == query) || (webviewId == malloyQuery && webviewSection == schemaQuery)"
+        "enablement": "(view == malloySchema && viewItem == query) || webviewSection == malloySchemaQuery"
+      },
+      {
+        "command": "malloy.runNamedQueryFromSchema",
+        "title": "Run",
+        "category": "Malloy",
+        "icon": "$(play)",
+        "enablement": "webviewSection == malloySchemaNamedQuery"
       },
       {
         "command": "malloy.copyFieldPath",
         "title": "Copy Path",
         "category": "Malloy",
         "icon": "$(copy)",
-        "enablement": "view == malloySchema || webviewId == malloyQuery"
+        "enablement": "view == malloySchema || webviewSection == malloySchemaQuery || webviewSection == malloySchemaField"
       },
       {
         "command": "malloy.goToDefinitionFromSchema",
         "title": "Go to Definition",
         "category": "Malloy",
-        "enablement": "view == malloySchema || webviewId == malloyQuery"
+        "enablement": "view == malloySchema || webviewSection == malloySchemaQuery || webviewSection == malloySchemaNamedQuery || webviewSection == malloySchemaField"
       },
       {
         "command": "malloy.previewFromSchema",
@@ -243,15 +250,19 @@
       "webview/context": [
         {
           "command": "malloy.goToDefinitionFromSchema",
-          "when": "webviewId == malloyQuery && (webviewSection == schemaField || webviewSection == schemaQuery)"
+          "when": " webviewSection == malloySchemaField || webviewSection == malloySchemaNamedQuery || webviewSection == malloySchemaQuery"
         },
         {
           "command": "malloy.runTurtleFromSchema",
-          "when": "webviewId == malloyQuery && webviewSection == schemaQuery"
+          "when": "webviewSection == malloySchemaQuery"
+        },
+        {
+          "command": "malloy.runNamedQueryFromSchema",
+          "when": "webviewSection == malloySchemaNamedQuery"
         },
         {
           "command": "malloy.copyFieldPath",
-          "when": "webviewId == malloyQuery && (webviewSection == schemaField || webviewSection == schemaQuery)"
+          "when": "webviewSection == malloySchemaField || webviewSection == malloySchemaQuery"
         }
       ]
     },

--- a/src/extension/notebook/renderer/schema_entry.ts
+++ b/src/extension/notebook/renderer/schema_entry.ts
@@ -122,6 +122,24 @@ export class SchemaRendererWrapper extends LitElement {
     this.postMessage?.({command, args});
   };
 
+  onContextClick = (event: MouseEvent, context: Record<string, unknown>) => {
+    event.stopPropagation();
+    context = {...context, preventDefaultContextMenuItems: true};
+    const root =
+      window.document.querySelector<HTMLElement>('.output_container');
+    if (!root) {
+      return;
+    }
+    root.dataset['vscodeContext'] = JSON.stringify(context);
+    root.dispatchEvent(
+      new MouseEvent('contextmenu', {
+        clientX: event.clientX,
+        clientY: event.clientY,
+        bubbles: true,
+      })
+    );
+  };
+
   constructor() {
     super();
   }
@@ -139,6 +157,7 @@ export class SchemaRendererWrapper extends LitElement {
       .onFieldClick=${this.onFieldClick}
       .onQueryClick=${this.onQueryClick}
       .onPreviewClick=${this.onPreviewClick}
+      .onContextClick=${this.onContextClick}
     />`;
   }
 }

--- a/src/extension/subscriptions.ts
+++ b/src/extension/subscriptions.ts
@@ -23,10 +23,11 @@
 
 import * as vscode from 'vscode';
 import {
-  runTurtleFromSchemaCommand,
-  previewFromSchemaCommand,
   SchemaProvider,
   goToDefinitionFromSchemaCommand,
+  previewFromSchemaCommand,
+  runNamedQueryFromSchemaCommand,
+  runTurtleFromSchemaCommand,
 } from './tree_views/schema_view';
 import {
   copyFieldPathCommand,
@@ -184,6 +185,13 @@ export const setupSubscriptions = (
     vscode.commands.registerCommand(
       'malloy.runTurtleFromSchema',
       runTurtleFromSchemaCommand
+    )
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'malloy.runNamedQueryFromSchema',
+      runNamedQueryFromSchemaCommand
     )
   );
 

--- a/src/extension/tree_views/schema_view.ts
+++ b/src/extension/tree_views/schema_view.ts
@@ -295,6 +295,10 @@ function getIconPath(
   return Utils.joinPath(uri, 'dist', imageFileName);
 }
 
+export function runNamedQueryFromSchemaCommand(item: {name: string}): void {
+  vscode.commands.executeCommand('malloy.runNamedQuery', item.name);
+}
+
 export function runTurtleFromSchemaCommand(item: {
   topLevelExplore: string;
   accessPath: string[];

--- a/src/extension/webviews/components/schema_renderer.ts
+++ b/src/extension/webviews/components/schema_renderer.ts
@@ -52,13 +52,14 @@ const sortByName = (a: {name: string}, b: {name: string}) =>
   a.name.localeCompare(b.name);
 
 const fieldContext = (field: Field) => {
-  const {fieldPath: accessPath, location} = field;
+  const {fieldPath: accessPath, location, name} = field;
   const topLevelExplore = accessPath.shift();
 
   return {
-    location,
-    topLevelExplore,
     accessPath,
+    location,
+    name,
+    topLevelExplore,
   };
 };
 /**
@@ -209,18 +210,17 @@ const queryItem = (
   };
 
   const clickable = onQueryClick ? 'clickable' : '';
-  let context: Record<string, unknown> = {
-    webviewSection: 'schemaQuery',
-  };
+  let context: Record<string, unknown> = {};
 
   if ('parentExplore' in query) {
     context = {
-      ...context,
+      webviewSection: 'malloySchemaQuery',
       ...fieldContext(query),
     };
   } else {
     context = {
-      ...context,
+      webviewSection: 'malloySchemaNamedQuery',
+      name: query.name,
       location: query.location,
     };
   }
@@ -271,7 +271,7 @@ export class StructItem extends LitElement {
 
   fieldItem(field: Field, path: string) {
     const context = {
-      webviewSection: 'schemaField',
+      webviewSection: 'malloySchemaField',
       ...fieldContext(field),
     };
 
@@ -394,7 +394,14 @@ export class SchemaRenderer extends LitElement {
         <div class="field_list">
           ${this.queries
             .sort(sortByName)
-            .map(query => queryItem(query, query.name, this.onQueryClick))}
+            .map(query =>
+              queryItem(
+                query,
+                query.name,
+                this.onQueryClick,
+                this.onContextClick
+              )
+            )}
         </div>
       </li>
       ${this.explores


### PR DESCRIPTION
VS Code notebook output cells all have the same `webviewId`, 'notebook.output'. So instead of using the `webviewId` as the context, just name our `webviewSection` more distinctly and use that. 

`.output_container` is the outmost element in the output cell that the webview context menu routine can see `data-vscode-context` on (thanks to shadow doms), so we copy our context onto that.

<img width="1360" alt="Screenshot 2023-12-14 at 12 48 38 PM" src="https://github.com/malloydata/malloy-vscode-extension/assets/2958002/8d2ef720-4d1d-417a-aa1c-53257484874b">
