### PR TITLE
Fix fixNotebookUrl

### DIFF
--- a/src/server/lenses/lenses.ts
+++ b/src/server/lenses/lenses.ts
@@ -60,9 +60,9 @@ const fixNotebookUrl = async (connection: Connection, url: URL) => {
     if (workspaceFolders && workspaceFolders[0]) {
       protocol = new URL(workspaceFolders[0].uri).protocol;
     }
-    const urlString = url
-      .toString()
-      .replace(/^vscode-notebook-cell:/, protocol);
+    const {pathname, search} = url;
+    const host = protocol === 'file:' ? '' : url.host;
+    const urlString = `${protocol}//${host}${pathname}${search}`;
     url = new URL(urlString);
   }
 


### PR DESCRIPTION
Use a less janky way of converting a notebook URL to a resource URL, including stripping out the host part if we're converting to a file URL.