### PR TITLE
Use platform neutral imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "posttest": "npm run lint",
     "preintegration": "npm run build-extension && tsc --project tsconfig.integration.json",
     "integration": "node ./integration/out/runTest.js",
-    "build-cloud-build-image": "./scripts/build_cloud_build_image.sh"
+    "build-cloud-build-image": "./scripts/build_cloud_build_image.sh",
+    "test-web": "vscode-test-web --extensionDevelopmentPath=."
   },
   "icon": "img/logo.png",
   "license": "MIT",

--- a/src/extension/tree_views/schema_view.ts
+++ b/src/extension/tree_views/schema_view.ts
@@ -31,7 +31,7 @@ import {
   AtomicField,
   DocumentLocation,
 } from '@malloydata/malloy';
-import {BaseLanguageClient} from 'vscode-languageclient/node';
+import {BaseLanguageClient} from 'vscode-languageclient';
 import {BuildModelRequest} from '../../common/types';
 import {
   exploreSubtype,

--- a/src/server/browser/server_browser.ts
+++ b/src/server/browser/server_browser.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {TextDocuments} from 'vscode-languageserver/browser';
+import {TextDocuments} from 'vscode-languageserver';
 import {TextDocument} from 'vscode-languageserver-textdocument';
 import {connection, connectionManager} from './connections_browser';
 import {initServer} from '../init';


### PR DESCRIPTION
Use the core language server types whenever possible.