### PR TITLE
fix: broken fixed col headers on scroll

### DIFF
--- a/src/extension/webviews/query_page/query_page.ts
+++ b/src/extension/webviews/query_page/query_page.ts
@@ -129,7 +129,8 @@ export class QueryPage extends LitElement {
       align-items: center;
     }
     .result-container {
-      margin: 10px;
+      padding: 10px;
+      height: calc(100% - 20px);
     }
     .scroll {
       flex: 1;


### PR DESCRIPTION
Fixes a bug where the new renderer column headers are properly fixed on scroll.

In order for this to work, the renderer result must be the scrolled element, not the wrapper elements outside of it. This change forces the renderer result to cap to a specific height so that it will be scrollable.