### PR TITLE
Allow copying CVS results to clipboard.

### DIFF
--- a/src/common/types/message_types.ts
+++ b/src/common/types/message_types.ts
@@ -130,6 +130,12 @@ export interface QueryDownloadOptions {
   amount: 'current' | 'all' | number;
 }
 
+export interface QueryDownloadCopyData {
+  type: string;
+  download: string;
+  data: string;
+}
+
 export type QueryPanelMessage =
   | QueryMessageStatus
   | QueryMessageAppReady

--- a/src/extension/webviews/components/popup_dialog.ts
+++ b/src/extension/webviews/components/popup_dialog.ts
@@ -41,7 +41,7 @@ const styles = css`
 
     &.open {
       display: flex;
-      z-index: 1;
+      z-index: 101;
     }
   }
 

--- a/src/extension/webviews/query_page/download_button.ts
+++ b/src/extension/webviews/query_page/download_button.ts
@@ -23,7 +23,10 @@
 
 import {LitElement, html} from 'lit';
 import {customElement, property} from 'lit/decorators.js';
-import {QueryDownloadOptions} from '../../../common/types/message_types';
+import {
+  QueryDownloadCopyData,
+  QueryDownloadOptions,
+} from '../../../common/types/message_types';
 import '../components/popup_dialog';
 import './download_form';
 import {
@@ -59,6 +62,9 @@ export class DownloadButton extends LitElement {
 
   @property()
   onDownload!: (options: QueryDownloadOptions) => Promise<void>;
+
+  @property()
+  onCopy!: (options: QueryDownloadCopyData) => Promise<void>;
 
   @property({type: Boolean})
   canStream!: boolean;
@@ -107,10 +113,14 @@ export class DownloadButton extends LitElement {
           .result=${this.result}
           ?canStream=${this.canStream}
           .onDownload=${async (options: QueryDownloadOptions) => {
-            this.open = false;
+            this.onClose();
             await this.onDownload(options);
           }}
           .onClose=${this.onClose}
+          .onCopy=${async (options: QueryDownloadCopyData) => {
+            this.onClose();
+            await this.onCopy(options);
+          }}
         ></download-form>
       </popup-dialog>`;
   }

--- a/src/extension/webviews/query_page/query_page.ts
+++ b/src/extension/webviews/query_page/query_page.ts
@@ -35,6 +35,7 @@ import {when} from 'lit/directives/when.js';
 import {MutationController} from '@lit-labs/observers/mutation-controller.js';
 
 import {
+  QueryDownloadCopyData,
   QueryDownloadOptions,
   QueryMessageStatus,
   QueryMessageType,
@@ -303,11 +304,7 @@ export class QueryPage extends LitElement {
               _target: HTMLElement,
               _drillFilters: string[]
             ) => {
-              const status = QueryRunStatus.RunCommand;
-              const command = 'malloy.copyToClipboard';
-              const args = [drillQuery, 'Query'];
-              // TODO(cbhagwat): Fix this.
-              this.vscode.postMessage({status, command, args});
+              this.copyToClipboard(drillQuery, 'Drill Query');
             },
           })
           .then(html => {
@@ -390,6 +387,9 @@ export class QueryPage extends LitElement {
                       downloadOptions,
                     });
                   }}
+                  .onCopy=${async ({data}: QueryDownloadCopyData) => {
+                    this.copyToClipboard(data, 'Results');
+                  }}
                 ></download-button>`
             )}
           </div>
@@ -401,7 +401,10 @@ export class QueryPage extends LitElement {
               ${this.results.html}
               <copy-button
                 .onCopy=${() =>
-                  this.copyToClipboard(this.getStyledHTML(this.results.html!))}
+                  this.copyToClipboard(
+                    this.getStyledHTML(this.results.html!),
+                    'HTML Results'
+                  )}
               >
               </copy-button>
             </div>`
@@ -417,7 +420,8 @@ export class QueryPage extends LitElement {
               >
               </prism-container>
               <copy-button
-                .onCopy=${() => this.copyToClipboard(this.results.json!)}
+                .onCopy=${() =>
+                  this.copyToClipboard(this.results.json!, 'JSON Results')}
               >
               </copy-button>
             </div>`
@@ -433,7 +437,11 @@ export class QueryPage extends LitElement {
               >
               </prism-container>
               <copy-button
-                .onCopy=${() => this.copyToClipboard(this.results.metadata!)}
+                .onCopy=${() =>
+                  this.copyToClipboard(
+                    this.results.metadata!,
+                    'Result Metadata'
+                  )}
               >
               </copy-button>
             </div>`
@@ -465,7 +473,8 @@ export class QueryPage extends LitElement {
                 >
                 </prism-container>
                 <copy-button
-                  .onCopy=${() => this.copyToClipboard(this.results.sql!)}
+                  .onCopy=${() =>
+                    this.copyToClipboard(this.results.sql!, 'SQL')}
                 >
                 </copy-button>
               </div>
@@ -528,11 +537,11 @@ export class QueryPage extends LitElement {
       : nothing;
   }
 
-  copyToClipboard(text: string) {
+  copyToClipboard(text: string, type: string) {
     const status = QueryRunStatus.RunCommand;
     const command = 'malloy.copyToClipboard';
-    const args = [text, 'Results'];
-    this.vscode.postMessage?.({status, command, args});
+    const args = [text, type];
+    this.vscode.postMessage({status, command, args});
   }
 
   onFieldClick = (field: Field) => {
@@ -545,7 +554,7 @@ export class QueryPage extends LitElement {
         path = `${current.name}.${path}`;
         current = current.parentExplore;
       }
-      this.copyToClipboard(path);
+      this.copyToClipboard(path, 'Path');
     }
   };
 


### PR DESCRIPTION
Currently you can sort of copy and paste to Excel via the HTML copy command, but it has unintended side effects like including rendering number formatting. You can download CSV's to disk, but that's a bunch of steps - this adds the ability to copy the CSV data directly to the clipboard via the download dialog.

Also cleans up some of the popup text that used to all say "Result" to be more specific, to clarify what's being copied by the floating copy button. 