### PR TITLE
Move connection test to worker

### DIFF
--- a/src/common/types/worker_message_types.ts
+++ b/src/common/types/worker_message_types.ts
@@ -32,6 +32,7 @@ import {QueryDownloadOptions} from './message_types';
 import {CellData} from './file_handler';
 import {MalloyConfig} from './malloy_config';
 import {QuerySpec} from './query_spec';
+import {ConnectionConfig} from './connection_manager_types';
 
 /*
  * Incoming messages
@@ -93,6 +94,10 @@ export interface MessageRefreshSchemaCache {
   uri: string;
 }
 
+export interface MessageTest {
+  config: ConnectionConfig;
+}
+
 export interface MessageFetchWorkspaceFolders {
   workspaceFolders: string[];
 }
@@ -116,6 +121,7 @@ export interface MessageMap {
   'malloy/run': MessageRun;
   'malloy/download': MessageDownload;
   'malloy/refreshSchemaCache': MessageRefreshSchemaCache;
+  'malloy/testConnection': MessageTest;
 }
 
 /**

--- a/src/extension/browser/commands/edit_connections.ts
+++ b/src/extension/browser/commands/edit_connections.ts
@@ -26,21 +26,24 @@ import {
   getDefaultIndex,
 } from '../../../common/types/connection_manager_types';
 import {EditConnectionPanel} from '../../connection_editor';
-import {ConnectionItem} from '../../tree_views/connections_view';
+import {WorkerConnection} from '../../worker_connection';
 import {connectionManager} from '../connection_manager';
 
 let panel: EditConnectionPanel | null = null;
 
-export function editConnectionsCommand({id}: ConnectionItem): void {
+export function editConnectionsCommand(
+  worker: WorkerConnection,
+  id?: string
+): void {
   if (!panel) {
     panel = new EditConnectionPanel(
       connectionManager,
+      worker,
       handleConnectionsPreSave
     );
     panel.onDidDispose(() => (panel = null));
-  } else {
-    panel.reveal(id);
   }
+  panel.reveal(id);
 }
 
 /**

--- a/src/extension/browser/extension_browser.ts
+++ b/src/extension/browser/extension_browser.ts
@@ -30,7 +30,10 @@ import {
 
 import {setupFileMessaging, setupSubscriptions} from '../subscriptions';
 import {connectionManager} from './connection_manager';
-import {ConnectionsProvider} from '../tree_views/connections_view';
+import {
+  ConnectionItem,
+  ConnectionsProvider,
+} from '../tree_views/connections_view';
 import {editConnectionsCommand} from './commands/edit_connections';
 import {fileHandler} from '../utils/files';
 import {WorkerConnectionBrowser} from './worker_connection_browser';
@@ -56,7 +59,7 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'malloy.editConnections',
-      editConnectionsCommand
+      (item?: ConnectionItem) => editConnectionsCommand(worker, item?.id)
     )
   );
 }

--- a/src/extension/connection_editor.ts
+++ b/src/extension/connection_editor.ts
@@ -35,6 +35,7 @@ import {ConnectionConfig} from '../common/types/connection_manager_types';
 import {errorMessage} from '../common/errors';
 import {ConnectionManager} from '../common/connection_manager';
 import {getMalloyConfig} from './utils/config';
+import {WorkerConnection} from './worker_connection';
 
 export class EditConnectionPanel {
   panel: vscode.WebviewPanel;
@@ -43,6 +44,7 @@ export class EditConnectionPanel {
 
   constructor(
     private connectionManager: ConnectionManager,
+    private worker: WorkerConnection,
     handleConnectionsPreSave: (
       connections: ConnectionConfig[]
     ) => Promise<ConnectionConfig[]>
@@ -94,10 +96,9 @@ export class EditConnectionPanel {
         }
         case ConnectionMessageType.TestConnection: {
           try {
-            const connection = await this.connectionManager.connectionForConfig(
-              message.connection
-            );
-            await connection.test();
+            await this.worker.sendRequest('malloy/testConnection', {
+              config: message.connection,
+            });
             this.messageManager.postMessage({
               type: ConnectionMessageType.TestConnection,
               status: ConnectionTestStatus.Success,

--- a/src/extension/node/commands/edit_connections.ts
+++ b/src/extension/node/commands/edit_connections.ts
@@ -28,19 +28,23 @@ import {
 } from '../../../common/types/connection_manager_types';
 import {deletePassword, setPassword} from 'keytar';
 import {EditConnectionPanel} from '../../connection_editor';
-import {ConnectionItem} from '../../tree_views/connections_view';
+import {WorkerConnection} from '../../worker_connection';
 
 let panel: EditConnectionPanel | null = null;
 
-export function editConnectionsCommand(item?: ConnectionItem): void {
+export function editConnectionsCommand(
+  worker: WorkerConnection,
+  id?: string
+): void {
   if (!panel) {
     panel = new EditConnectionPanel(
       connectionManager,
+      worker,
       handleConnectionsPreSave
     );
     panel.onDidDispose(() => (panel = null));
   }
-  panel.reveal(item?.id);
+  panel.reveal(id);
 }
 
 /**

--- a/src/extension/node/extension_node.ts
+++ b/src/extension/node/extension_node.ts
@@ -31,7 +31,10 @@ import {
   TransportKind,
 } from 'vscode-languageclient/node';
 import {editConnectionsCommand} from './commands/edit_connections';
-import {ConnectionsProvider} from '../tree_views/connections_view';
+import {
+  ConnectionItem,
+  ConnectionsProvider,
+} from '../tree_views/connections_view';
 import {connectionManager} from './connection_manager';
 import {setupFileMessaging, setupSubscriptions} from '../subscriptions';
 import {getMalloyConfig} from '../utils/config';
@@ -73,7 +76,7 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'malloy.editConnections',
-      editConnectionsCommand
+      (item?: ConnectionItem) => editConnectionsCommand(worker, item?.id)
     )
   );
 

--- a/src/worker/message_handler.ts
+++ b/src/worker/message_handler.ts
@@ -22,6 +22,7 @@
  */
 
 import {runQuery} from './run_query';
+import {testConnection} from './test_connection';
 import {
   GenericConnection,
   ListenerType,
@@ -52,6 +53,10 @@ export class MessageHandler implements WorkerMessageHandler {
         message,
         cancellationToken
       )
+    );
+
+    this.onRequest('malloy/testConnection', message =>
+      testConnection(connectionManager, message.config)
     );
   }
 

--- a/src/worker/test_connection.ts
+++ b/src/worker/test_connection.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {ConnectionManager} from '../common/connection_manager';
+import {ConnectionConfig} from '../common/types/connection_manager_types';
+
+export async function testConnection(
+  connectionManager: ConnectionManager,
+  config: ConnectionConfig
+) {
+  const connection = await connectionManager.connectionForConfig(config);
+  await connection.test();
+}


### PR DESCRIPTION
Remove all actual database connections out of the extension, in preparation for supporting duckdb databases.