### PR TITLE
Migrate from keytar to vscode secret API

### DIFF
--- a/src/common/connections/node/connection_factory.ts
+++ b/src/common/connections/node/connection_factory.ts
@@ -34,10 +34,13 @@ import {createPostgresConnection} from '../postgres_connection';
 
 import {fileURLToPath} from 'url';
 import {ExternalConnectionFactory} from '../external_connection_factory';
+import {GenericConnection} from '../../types/worker_message_types';
 
 export class NodeConnectionFactory implements ConnectionFactory {
   connectionCache: Record<string, TestableConnection> = {};
   externalConnectionFactory = new ExternalConnectionFactory();
+
+  constructor(private client: GenericConnection) {}
 
   reset() {
     Object.values(this.connectionCache).forEach(connection =>
@@ -66,6 +69,7 @@ export class NodeConnectionFactory implements ConnectionFactory {
         break;
       case ConnectionBackend.Postgres: {
         connection = await createPostgresConnection(
+          this.client,
           connectionConfig,
           configOptions
         );

--- a/src/common/types/worker_message_types.ts
+++ b/src/common/types/worker_message_types.ts
@@ -134,6 +134,10 @@ export interface WorkerFetchWorkspaceFoldersMessage {
   uri: string;
 }
 
+export interface WorkerGetSecretMessage {
+  key: string;
+}
+
 /**
  * Map of worker message types to worker message interfaces.
  */
@@ -143,6 +147,7 @@ export interface WorkerMessageMap {
   'malloy/fetch': WorkerFetchMessage;
   'malloy/fetchCellData': WorkerFetchCellDataMessage;
   'malloy/fetchWorkspaceFolders': WorkerFetchWorkspaceFoldersMessage;
+  'malloy/getSecret': WorkerGetSecretMessage;
 }
 
 /**

--- a/src/extension/browser/commands/edit_connections.ts
+++ b/src/extension/browser/commands/edit_connections.ts
@@ -71,12 +71,12 @@ async function handleConnectionsPreSave(
         await context.secrets.delete(key);
       }
       if (connection.password) {
+        await context.secrets.store(key, connection.password);
         modifiedConnections.push({
           ...connection,
           password: undefined,
           useKeychainPassword: true,
         });
-        await context.secrets.store(key, connection.password);
       }
     } else {
       modifiedConnections.push(connection);

--- a/src/extension/browser/extension_browser.ts
+++ b/src/extension/browser/extension_browser.ts
@@ -37,6 +37,7 @@ import {
 import {editConnectionsCommand} from './commands/edit_connections';
 import {fileHandler} from '../utils/files';
 import {WorkerConnectionBrowser} from './worker_connection_browser';
+import {WorkerGetSecretMessage} from '../../common/types/worker_message_types';
 let client: LanguageClient;
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -62,7 +63,16 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       'malloy.editConnections',
-      (item?: ConnectionItem) => editConnectionsCommand(worker, item?.id)
+      (item?: ConnectionItem) =>
+        editConnectionsCommand(context, worker, item?.id)
+    )
+  );
+  context.subscriptions.push(
+    client.onRequest(
+      'malloy/getSecret',
+      async ({key}: WorkerGetSecretMessage) => {
+        return await context.secrets.get(key);
+      }
     )
   );
 }

--- a/src/extension/node/commands/edit_connections.ts
+++ b/src/extension/node/commands/edit_connections.ts
@@ -74,12 +74,12 @@ async function handleConnectionsPreSave(
         await context.secrets.delete(key);
       }
       if (connection.password) {
+        await context.secrets.store(key, connection.password);
         modifiedConnections.push({
           ...connection,
           password: undefined,
           useKeychainPassword: true,
         });
-        await context.secrets.store(key, connection.password);
       }
     } else {
       modifiedConnections.push(connection);

--- a/src/extension/webviews/connections_page/connection_editor/postgres_connection_editor.ts
+++ b/src/extension/webviews/connections_page/connection_editor/postgres_connection_editor.ts
@@ -181,7 +181,7 @@ export class PostgresConnectionEditor extends LitElement {
                   }
                 }}
               >
-                Enter a password ${this.config.password !== undefined && ':'}
+                Enter a password
               </vscode-radio>
             </div>
           </td>

--- a/src/server/browser/connections_browser.ts
+++ b/src/server/browser/connections_browser.ts
@@ -28,25 +28,12 @@ import {
 } from 'vscode-languageserver/browser';
 import {ConnectionManager} from '../../common/connection_manager';
 import {WebConnectionFactory} from '../../common/connections/browser/connection_factory';
-import {errorMessage} from '../../common/errors';
 
 const messageReader = new BrowserMessageReader(self as unknown as Worker);
 const messageWriter = new BrowserMessageWriter(self as unknown as Worker);
 
 export const connection = createConnection(messageReader, messageWriter);
 
-const fetchBinaryFile = async (uri: string): Promise<Uint8Array> => {
-  try {
-    connection.console.info(`fetchBinaryFile requesting ${uri}`);
-    return await connection.sendRequest('malloy/fetchBinaryFile', {uri});
-  } catch (error) {
-    connection.console.error(errorMessage(error));
-    throw new Error(
-      `fetchBinaryFile: unable to load '${uri}': ${errorMessage(error)}`
-    );
-  }
-};
-
 export const connectionManager = new ConnectionManager(
-  new WebConnectionFactory(fetchBinaryFile)
+  new WebConnectionFactory(connection)
 );

--- a/src/server/node/connections_node.ts
+++ b/src/server/node/connections_node.ts
@@ -28,5 +28,5 @@ import {NodeConnectionFactory} from '../../common/connections/node/connection_fa
 export const connection = createConnection(ProposedFeatures.all);
 
 export const connectionManager = new ConnectionManager(
-  new NodeConnectionFactory()
+  new NodeConnectionFactory(connection)
 );


### PR DESCRIPTION
keytar is EOLed, VS Code has its own secret manager, so use that instead. Since it's only available to the extension, add a message to allow the LSP to retrieve secrets. 

This will also allow the web version to support secrets eventually.

For now this will read and delete the old value from keytar, within a few releases we should remove keytar and unify the node and browser code paths where possible.