### PR TITLE
MotherDuck token editor

### DIFF
--- a/src/common/connection_manager.ts
+++ b/src/common/connection_manager.ts
@@ -69,11 +69,13 @@ export class ConnectionManager {
   constructor(private connectionFactory: ConnectionFactory) {}
 
   public async connectionForConfig(
-    connectionConfig: ConnectionConfig
+    connectionConfig: ConnectionConfig,
+    options: ConfigOptions
   ): Promise<TestableConnection> {
-    return this.connectionFactory.getConnectionForConfig(connectionConfig, {
-      workingDirectory: '/',
-    });
+    return this.connectionFactory.getConnectionForConfig(
+      connectionConfig,
+      options
+    );
   }
 
   public getConnectionLookup(fileURL: URL): LookupConnection<Connection> {
@@ -103,6 +105,7 @@ export class ConnectionManager {
 
   public setConnectionsConfig(connectionsConfig: ConnectionConfig[]): void {
     // Force existing connections to be regenerated
+    this.connectionFactory.reset();
     console.info('Using connection config', connectionsConfig);
     this.configList = connectionsConfig;
     this.buildConfigMap();

--- a/src/common/connections/node/connection_factory.ts
+++ b/src/common/connections/node/connection_factory.ts
@@ -77,6 +77,7 @@ export class NodeConnectionFactory implements ConnectionFactory {
       }
       case ConnectionBackend.DuckDB: {
         connection = await createDuckDbConnection(
+          this.client,
           connectionConfig,
           configOptions
         );

--- a/src/common/connections/postgres_connection.ts
+++ b/src/common/connections/postgres_connection.ts
@@ -31,8 +31,9 @@ import {GenericConnection} from '../types/worker_message_types';
 export const createPostgresConnection = async (
   client: GenericConnection,
   connectionConfig: PostgresConnectionConfig,
-  {rowLimit}: ConfigOptions
+  {rowLimit, useKeyStore}: ConfigOptions
 ): Promise<PostgresConnection> => {
+  useKeyStore ??= true;
   const {username, host, port, databaseName, connectionString} =
     connectionConfig;
   const options = {
@@ -44,7 +45,7 @@ export const createPostgresConnection = async (
   };
   const configReader = async () => {
     let password: string | undefined;
-    if (connectionConfig.useKeychainPassword) {
+    if (useKeyStore) {
       password = await client.sendRequest('malloy/getSecret', {
         key: `connections.${connectionConfig.id}.password`,
       });

--- a/src/common/types/connection_manager_types.ts
+++ b/src/common/types/connection_manager_types.ts
@@ -76,6 +76,7 @@ export interface DuckDBConnectionConfig extends BaseConnectionConfig {
   backend: ConnectionBackend.DuckDB;
   workingDirectory?: string;
   databasePath?: string;
+  motherDuckToken?: string;
 }
 
 export interface ExternalConnectionPackageInfo {
@@ -115,6 +116,7 @@ export interface ConfigOptions {
   workingDirectory?: string;
   rowLimit?: number;
   useCache?: boolean;
+  useKeyStore?: boolean;
 }
 
 export interface ConnectionConfigManager {

--- a/src/extension/browser/commands/edit_connections.ts
+++ b/src/extension/browser/commands/edit_connections.ts
@@ -39,11 +39,31 @@ export function editConnectionsCommand(
       connectionConfigManager,
       worker,
       (connections: ConnectionConfig[]) =>
+        handleConnectionsPreLoad(context, connections),
+      (connections: ConnectionConfig[]) =>
         handleConnectionsPreSave(context, connections)
     );
     panel.onDidDispose(() => (panel = null));
   }
   panel.reveal(id);
+}
+
+/**
+ * Perform setup on the connections being sent to the webview.
+ *
+ * @param connections The connection configs.
+ * @returns An updated list of connections
+ *
+ * - Handles scrubbing passwords and putting them in the keychain.
+ */
+// TODO(whscullin) keytar
+// This can be moved to common code once keytar is removed
+async function handleConnectionsPreLoad(
+  _context: vscode.ExtensionContext,
+  connections: ConnectionConfig[]
+): Promise<ConnectionConfig[]> {
+  // Currently no-op in browser
+  return connections;
 }
 
 /**
@@ -58,29 +78,9 @@ export function editConnectionsCommand(
 // TODO(whscullin) keytar
 // This can be moved to common code once keytar is removed
 async function handleConnectionsPreSave(
-  context: vscode.ExtensionContext,
+  _context: vscode.ExtensionContext,
   connections: ConnectionConfig[]
 ): Promise<ConnectionConfig[]> {
-  const modifiedConnections = [];
-  for (let index = 0; index < connections.length; index++) {
-    const connection = connections[index];
-    if ('password' in connection) {
-      const key = `connections.${connection.id}.password`;
-      if (connection.useKeychainPassword === false) {
-        connection.useKeychainPassword = undefined;
-        await context.secrets.delete(key);
-      }
-      if (connection.password) {
-        await context.secrets.store(key, connection.password);
-        modifiedConnections.push({
-          ...connection,
-          password: undefined,
-          useKeychainPassword: true,
-        });
-      }
-    } else {
-      modifiedConnections.push(connection);
-    }
-  }
-  return modifiedConnections;
+  // Currently no-op in browser
+  return connections;
 }

--- a/src/extension/webviews/components/schema_renderer.ts
+++ b/src/extension/webviews/components/schema_renderer.ts
@@ -321,9 +321,9 @@ export class StructItem extends LitElement {
 
     return html`<li class=${classes} title=${buildTitle(explore, path)}>
       <div @click=${this.toggleHidden}>
-        <span class="chevron"
-          >${this.hidden ? chevronRightIcon : chevronDownIcon}</span
-        >
+        <span class="chevron">
+          ${this.hidden ? chevronRightIcon : chevronDownIcon}
+        </span>
         ${getIconElement(`struct_${subtype}`, false)}
         <b class="explore_name">${getExploreName(explore, path)}</b>
         ${this.onPreviewClick

--- a/src/extension/webviews/connections_page/connection_editor/components/secret_editor.ts
+++ b/src/extension/webviews/connections_page/connection_editor/components/secret_editor.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {LitElement, html} from 'lit';
+import {
+  provideVSCodeDesignSystem,
+  vsCodeButton,
+  vsCodeCheckbox,
+  vsCodeTextField,
+} from '@vscode/webview-ui-toolkit';
+import {customElement, property} from 'lit/decorators.js';
+import {styles} from '../connection_editor.css';
+import {when} from 'lit/directives/when.js';
+
+provideVSCodeDesignSystem().register(
+  vsCodeButton(),
+  vsCodeCheckbox(),
+  vsCodeTextField()
+);
+
+@customElement('secret-editor')
+class SecretEditor extends LitElement {
+  static override styles = [styles];
+
+  @property()
+  secret?: string;
+  @property()
+  setSecret!: (secret: string) => void;
+
+  @property({attribute: false})
+  showSecret = false;
+
+  @property({attribute: false})
+  settingSecret = false;
+
+  override render() {
+    return html`
+      <div>
+        ${when(
+          this.settingSecret,
+          () =>
+            html`<div class="button-group">
+              <vscode-text-field
+                @change=${({target: {value}}: {target: HTMLInputElement}) => {
+                  this.setSecret(value);
+                }}
+                type=${this.showSecret ? 'text' : 'password'}
+              ></vscode-text-field>
+              <vscode-button
+                @click=${() => {
+                  this.settingSecret = false;
+                }}
+              >
+                Cancel
+              </vscode-button>
+              <vscode-checkbox
+                .checked=${this.showSecret}
+                @change=${({target}: {target: HTMLInputElement}) => {
+                  this.showSecret = target.checked;
+                }}
+              >
+                Show Password
+              </vscode-checkbox>
+            </div>`,
+          () =>
+            html`<div class="button-group">
+              <vscode-button
+                @click=${() => {
+                  this.settingSecret = true;
+                }}
+              >
+                ${this.secret ? 'Change' : 'Set'}
+              </vscode-button>
+              ${when(
+                this.secret,
+                () =>
+                  html` <vscode-button
+                    @click=${() => {
+                      this.setSecret('');
+                    }}
+                  >
+                    Clear
+                  </vscode-button>`
+              )}
+            </div>`
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'secret-editor': SecretEditor;
+  }
+}

--- a/src/extension/webviews/connections_page/connection_editor/duckdb_connection_editor.ts
+++ b/src/extension/webviews/connections_page/connection_editor/duckdb_connection_editor.ts
@@ -31,6 +31,8 @@ import {
 import {DuckDBConnectionConfig} from '../../../../common/types/connection_manager_types';
 import {customElement, property} from 'lit/decorators.js';
 import {styles} from './connection_editor.css';
+import {when} from 'lit/directives/when.js';
+import './components/secret_editor';
 
 provideVSCodeDesignSystem().register(
   vsCodeCheckbox(),
@@ -109,6 +111,23 @@ export class DuckDBConnectionEditor extends LitElement {
             </vscode-button>
           </td>
         </tr>
+        ${when(
+          this.config.databasePath?.startsWith('md:'),
+          () =>
+            html`<tr>
+              <td class="label-cell">
+                <label>MotherDuck Token:</label>
+              </td>
+              <td>
+                <secret-editor
+                  .secret=${this.config.motherDuckToken}
+                  .setSecret=${(secret: string) => {
+                    this.setConfig({...this.config, motherDuckToken: secret});
+                  }}
+                ></secret-editor>
+              </td>
+            </tr>`
+        )}
       </tbody>
     </table>`;
   }

--- a/src/extension/webviews/connections_page/connection_editor/postgres_connection_editor.ts
+++ b/src/extension/webviews/connections_page/connection_editor/postgres_connection_editor.ts
@@ -24,19 +24,13 @@
 import {LitElement, html} from 'lit';
 import {
   provideVSCodeDesignSystem,
-  vsCodeCheckbox,
-  vsCodeRadio,
   vsCodeTextField,
 } from '@vscode/webview-ui-toolkit';
 import {PostgresConnectionConfig} from '../../../../common/types/connection_manager_types';
 import {customElement, property} from 'lit/decorators.js';
 import {styles} from './connection_editor.css';
 
-provideVSCodeDesignSystem().register(
-  vsCodeCheckbox(),
-  vsCodeRadio(),
-  vsCodeTextField()
-);
+provideVSCodeDesignSystem().register(vsCodeTextField());
 
 @customElement('postgres-connection-editor')
 export class PostgresConnectionEditor extends LitElement {
@@ -46,9 +40,6 @@ export class PostgresConnectionEditor extends LitElement {
   config!: PostgresConnectionConfig;
   @property()
   setConfig!: (config: PostgresConnectionConfig) => void;
-
-  @property({attribute: false})
-  showPassword = false;
 
   override render() {
     return html`<table>
@@ -123,97 +114,14 @@ export class PostgresConnectionEditor extends LitElement {
             <label>Password:</label>
           </td>
           <td>
-            ${this.config.useKeychainPassword !== undefined &&
-            html`<div>
-              <vscode-radio
-                value="keychain"
-                .checked=${this.config.useKeychainPassword || false}
-                @change=${({target}: {target: HTMLInputElement}) => {
-                  if (target.checked) {
-                    this.setConfig({
-                      ...this.config,
-                      password: undefined,
-                      useKeychainPassword: true,
-                    });
-                  }
-                }}
-              >
-                Use existing value
-              </vscode-radio>
-            </div>`}
-            <div>
-              <vscode-radio
-                value="none"
-                key="none"
-                .checked=${!this.config.useKeychainPassword &&
-                this.config.password === undefined}
-                @change=${({target}: {target: HTMLInputElement}) => {
-                  if (target.checked) {
-                    this.setConfig({
-                      ...this.config,
-                      password: undefined,
-                      useKeychainPassword:
-                        this.config.useKeychainPassword === undefined
-                          ? undefined
-                          : false,
-                    });
-                  }
-                }}
-              >
-                No password
-              </vscode-radio>
-            </div>
-            <div>
-              <vscode-radio
-                value="specified"
-                key="specified"
-                .checked=${this.config.password !== undefined}
-                @change=${({target}: {target: HTMLInputElement}) => {
-                  if (target.checked) {
-                    this.setConfig({
-                      ...this.config,
-                      password: '',
-                      useKeychainPassword:
-                        this.config.useKeychainPassword === undefined
-                          ? undefined
-                          : false,
-                    });
-                  }
-                }}
-              >
-                Enter a password
-              </vscode-radio>
-            </div>
+            <secret-editor
+              .secret=${this.config.password}
+              .setSecret=${(secret: string) => {
+                this.setConfig({...this.config, password: secret});
+              }}
+            ></secret-editor>
           </td>
         </tr>
-        ${this.config.password !== undefined
-          ? html`<tr>
-              <td></td>
-              <td>
-                <vscode-text-field
-                  value=${this.config.password || ''}
-                  @change=${({target: {value}}: {target: HTMLInputElement}) => {
-                    this.setConfig({
-                      ...this.config,
-                      password: value,
-                    });
-                  }}
-                  type=${this.showPassword ? 'text' : 'password'}
-                  placeholder="Optional"
-                ></vscode-text-field>
-              </td>
-              <td style="padding-left: 10px">
-                <vscode-checkbox
-                  .checked=${this.showPassword}
-                  @change=${({target}: {target: HTMLInputElement}) => {
-                    this.showPassword = target.checked;
-                  }}
-                >
-                  Show Password
-                </vscode-checkbox>
-              </td>
-            </tr>`
-          : null}
         <tr>
           <td class="label-cell">
             <label> Connection URL <i>(Advanced)</i>: </label>

--- a/src/extension/webviews/connections_page/connection_editor_list.ts
+++ b/src/extension/webviews/connections_page/connection_editor_list.ts
@@ -120,9 +120,9 @@ export class ConnectionEditorList extends LitElement {
   override render() {
     return html` <div style="marginTop: 20px">
       <div class="button-group" style="margin: 10px">
-        <vscode-button @click=${this.addConnection}
-          >New Connection</vscode-button
-        >
+        <vscode-button @click=${this.addConnection}>
+          New Connection
+        </vscode-button>
       </div>
       ${this.connections.map((config, index) =>
         this.selectedId === config.id

--- a/src/worker/test_connection.ts
+++ b/src/worker/test_connection.ts
@@ -28,6 +28,9 @@ export async function testConnection(
   connectionManager: ConnectionManager,
   config: ConnectionConfig
 ) {
-  const connection = await connectionManager.connectionForConfig(config);
+  const connection = await connectionManager.connectionForConfig(config, {
+    useCache: false,
+    useKeyStore: false,
+  });
   await connection.test();
 }


### PR DESCRIPTION
Simplify and abstract Postgres password editor to allow for re-use with MotherDuck token.
<img width="501" alt="Screenshot 2024-02-14 at 9 11 19 AM" src="https://github.com/malloydata/malloy-vscode-extension/assets/2958002/49ea2682-3b73-42ba-aad5-e0f6d8e65e1c">
<img width="567" alt="Screenshot 2024-02-14 at 9 11 34 AM" src="https://github.com/malloydata/malloy-vscode-extension/assets/2958002/93325835-3dde-40b7-8b41-611efa87a0d7">
<img width="579" alt="Screenshot 2024-02-14 at 9 11 54 AM" src="https://github.com/malloydata/malloy-vscode-extension/assets/2958002/5fc89210-5389-4baa-ad46-54194aea5afd">
<img width="498" alt="Screenshot 2024-02-14 at 9 12 18 AM" src="https://github.com/malloydata/malloy-vscode-extension/assets/2958002/24f7590b-5db5-4643-8550-05b63e320cf4">

