### PR TITLE
Clean up test error messages

### DIFF
--- a/src/extension/connection_editor.ts
+++ b/src/extension/connection_editor.ts
@@ -104,9 +104,15 @@ export class EditConnectionPanel {
         }
         case ConnectionMessageType.TestConnection: {
           try {
-            await this.worker.sendRequest('malloy/testConnection', {
-              config: message.connection,
-            });
+            const result: string = await this.worker.sendRequest(
+              'malloy/testConnection',
+              {
+                config: message.connection,
+              }
+            );
+            if (result) {
+              throw new Error(result);
+            }
             this.messageManager.postMessage({
               type: ConnectionMessageType.TestConnection,
               status: ConnectionTestStatus.Success,

--- a/src/worker/message_handler.ts
+++ b/src/worker/message_handler.ts
@@ -34,6 +34,7 @@ import {ConnectionManager} from '../common/connection_manager';
 import {RpcFileHandler} from './file_handler';
 import {FileHandler} from '../common/types/file_handler';
 import {ProgressType} from 'vscode-jsonrpc';
+import {errorMessage} from '../common/errors';
 
 export class MessageHandler implements WorkerMessageHandler {
   public fileHandler: FileHandler;
@@ -55,9 +56,14 @@ export class MessageHandler implements WorkerMessageHandler {
       )
     );
 
-    this.onRequest('malloy/testConnection', message =>
-      testConnection(connectionManager, message.config)
-    );
+    this.onRequest('malloy/testConnection', async message => {
+      try {
+        await testConnection(connectionManager, message.config);
+      } catch (error) {
+        return errorMessage(error);
+      }
+      return '';
+    });
   }
 
   onRequest<K extends keyof MessageMap>(


### PR DESCRIPTION
json-rpc adds it's own preamble to thrown error messages, so just return the error message and throw it on the client side.