### PR TITLE
Make duckdb-wasm match duckdb

### DIFF
--- a/src/common/connections/browser/connection_factory.ts
+++ b/src/common/connections/browser/connection_factory.ts
@@ -81,7 +81,11 @@ export class WebConnectionFactory implements ConnectionFactory {
             return this.fetchBinaryFile(url.toString());
           };
           const duckDBConnection: DuckDBWASMConnection =
-            await createDuckDbWasmConnection(connectionConfig, configOptions);
+            await createDuckDbWasmConnection(
+              this.client,
+              connectionConfig,
+              configOptions
+            );
           duckDBConnection.registerRemoteTableCallback(remoteTableCallback);
           connection = duckDBConnection;
         }

--- a/src/common/connections/duckdb_connection.ts
+++ b/src/common/connections/duckdb_connection.ts
@@ -53,9 +53,7 @@ export const createDuckDbConnection = async (
     console.info('Creating duckdb connection with', JSON.stringify(options));
     const connection = new DuckDBConnection(
       {
-        name,
-        databasePath,
-        workingDirectory,
+        ...options,
         motherDuckToken,
       },
       () => ({rowLimit})


### PR DESCRIPTION
In preparation for MotherDuck support in WASM, and to prevent editing a DuckDB connection accidentally overwriting the token.