### PR TITLE
Make input more responsive

### DIFF
--- a/src/extension/webviews/connections_page/connection_editor/bigquery_connection_editor.ts
+++ b/src/extension/webviews/connections_page/connection_editor/bigquery_connection_editor.ts
@@ -73,7 +73,7 @@ export class BigQueryConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.name}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, name: value});
               }}
             ></vscode-text-field>
@@ -86,7 +86,7 @@ export class BigQueryConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.projectId || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, projectId: value});
               }}
               placeholder="Optional"
@@ -100,7 +100,7 @@ export class BigQueryConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.billingProjectId || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, billingProjectId: value});
               }}
               placeholder="Optional"
@@ -114,7 +114,7 @@ export class BigQueryConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.location || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, location: value});
               }}
               placeholder="Optional (default US)"
@@ -128,7 +128,7 @@ export class BigQueryConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.serviceAccountKeyPath || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, serviceAccountKeyPath: value});
               }}
               placeholder="Optional"
@@ -147,7 +147,7 @@ export class BigQueryConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.maximumBytesBilled || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, maximumBytesBilled: value});
               }}
               placeholder="Optional"
@@ -161,7 +161,7 @@ export class BigQueryConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.timeoutMs || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, timeoutMs: value});
               }}
               placeholder="Optional"

--- a/src/extension/webviews/connections_page/connection_editor/components/secret_editor.ts
+++ b/src/extension/webviews/connections_page/connection_editor/components/secret_editor.ts
@@ -21,7 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-import {LitElement, html} from 'lit';
+import {LitElement, css, html} from 'lit';
 import {
   provideVSCodeDesignSystem,
   vsCodeButton,
@@ -38,9 +38,17 @@ provideVSCodeDesignSystem().register(
   vsCodeTextField()
 );
 
+const columnStyle = css`
+  .column {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+  }
+`;
+
 @customElement('secret-editor')
 class SecretEditor extends LitElement {
-  static override styles = [styles];
+  static override styles = [styles, columnStyle];
 
   @property()
   secret?: string;
@@ -53,35 +61,47 @@ class SecretEditor extends LitElement {
   @property({attribute: false})
   settingSecret = false;
 
+  currentSecret = '';
+
   override render() {
     return html`
-      <div>
+      <div class="column">
         ${when(
           this.settingSecret,
           () =>
             html`<div class="button-group">
-              <vscode-text-field
-                @change=${({target: {value}}: {target: HTMLInputElement}) => {
-                  this.setSecret(value);
-                }}
-                type=${this.showSecret ? 'text' : 'password'}
-              ></vscode-text-field>
-              <vscode-button
-                @click=${() => {
-                  this.settingSecret = false;
-                }}
-              >
-                Cancel
-              </vscode-button>
-              <vscode-checkbox
-                .checked=${this.showSecret}
-                @change=${({target}: {target: HTMLInputElement}) => {
-                  this.showSecret = target.checked;
-                }}
-              >
-                Show Password
-              </vscode-checkbox>
-            </div>`,
+                <vscode-text-field
+                  @change=${({target: {value}}: {target: HTMLInputElement}) => {
+                    this.currentSecret = value;
+                  }}
+                  type=${this.showSecret ? 'text' : 'password'}
+                ></vscode-text-field>
+              </div>
+              <div class="button-group">
+                <vscode-button
+                  @click=${() => {
+                    this.settingSecret = false;
+                    this.setSecret(this.currentSecret);
+                  }}
+                >
+                  ${this.secret ? 'Change' : 'Set'}
+                </vscode-button>
+                <vscode-button
+                  @click=${() => {
+                    this.settingSecret = false;
+                  }}
+                >
+                  Cancel
+                </vscode-button>
+                <vscode-checkbox
+                  .checked=${this.showSecret}
+                  @change=${({target}: {target: HTMLInputElement}) => {
+                    this.showSecret = target.checked;
+                  }}
+                >
+                  Show Secret
+                </vscode-checkbox>
+              </div>`,
           () =>
             html`<div class="button-group">
               <vscode-button

--- a/src/extension/webviews/connections_page/connection_editor/duckdb_connection_editor.ts
+++ b/src/extension/webviews/connections_page/connection_editor/duckdb_connection_editor.ts
@@ -73,7 +73,7 @@ export class DuckDBConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.name}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, name: value});
               }}
             ></vscode-text-field>
@@ -86,7 +86,7 @@ export class DuckDBConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.workingDirectory || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, workingDirectory: value});
               }}
             ></vscode-text-field>
@@ -100,7 +100,7 @@ export class DuckDBConnectionEditor extends LitElement {
             <vscode-text-field
               value=${this.config.databasePath || ''}
               placeholder=":memory:"
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, databasePath: value});
               }}
             ></vscode-text-field>

--- a/src/extension/webviews/connections_page/connection_editor/external_connection_editor.ts
+++ b/src/extension/webviews/connections_page/connection_editor/external_connection_editor.ts
@@ -124,7 +124,7 @@ export class ExternalConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.path || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({
                   ...this.config,
                   path: value.trim(),
@@ -164,7 +164,7 @@ export class ExternalConnectionEditor extends LitElement {
               <td>
                 <vscode-text-field
                   value=${this.config.name}
-                  @change=${({target: {value}}: {target: HTMLInputElement}) => {
+                  @input=${({target: {value}}: {target: HTMLInputElement}) => {
                     this.setConfig({...this.config, name: value});
                   }}
                 ></vscode-text-field>
@@ -189,7 +189,7 @@ export class ExternalConnectionEditor extends LitElement {
                     : ''}
                   value=${(this.config.configParameters?.[parameter.name] ||
                     '') as string}
-                  @change=${({target: {value}}: {target: HTMLInputElement}) => {
+                  @input=${({target: {value}}: {target: HTMLInputElement}) => {
                     const configParameters =
                       this.config.configParameters ?? ({} as ConnectionConfig);
                     let configParameterValue: ConnectionParameterValue = value;

--- a/src/extension/webviews/connections_page/connection_editor/postgres_connection_editor.ts
+++ b/src/extension/webviews/connections_page/connection_editor/postgres_connection_editor.ts
@@ -50,8 +50,8 @@ export class PostgresConnectionEditor extends LitElement {
           </td>
           <td>
             <vscode-text-field
-              value=${this.config.name}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              input=${this.config.name}
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, name: value});
               }}
             ></vscode-text-field>
@@ -64,7 +64,7 @@ export class PostgresConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.host || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, host: value});
               }}
             ></vscode-text-field>
@@ -77,7 +77,7 @@ export class PostgresConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.port ? this.config.port.toString() : ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, port: parseInt(value)});
               }}
             ></vscode-text-field>
@@ -90,7 +90,7 @@ export class PostgresConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.databaseName || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, databaseName: value});
               }}
             ></vscode-text-field>
@@ -103,7 +103,7 @@ export class PostgresConnectionEditor extends LitElement {
           <td>
             <vscode-text-field
               value=${this.config.username || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, username: value});
               }}
             ></vscode-text-field>
@@ -130,7 +130,7 @@ export class PostgresConnectionEditor extends LitElement {
             <vscode-text-field
               style="width: 40em"
               value=${this.config.connectionString || ''}
-              @change=${({target: {value}}: {target: HTMLInputElement}) => {
+              @input=${({target: {value}}: {target: HTMLInputElement}) => {
                 this.setConfig({...this.config, connectionString: value});
               }}
             ></vscode-text-field>

--- a/src/extension/webviews/query_page/download_form.ts
+++ b/src/extension/webviews/query_page/download_form.ts
@@ -228,7 +228,7 @@ export class DownloadForm extends LitElement {
                 ? html`<div class="form-row">
                     <vscode-text-field
                       value=${this.rowLimit.toString()}
-                      @change=${({
+                      @input=${({
                         target: {value},
                       }: {
                         target: HTMLInputElement;


### PR DESCRIPTION
Use `input` instead of `change` events for text `<input>` elements because the changes are reflected immediately without having to tab away from the field. This makes the "Save" button more responsive.