### PR TITLE
Enforce no floating promises 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 build/
 out/
+third_party/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,5 @@
 {
   "extends": ["./node_modules/gts/", "plugin:lit/recommended"],
-  "parserOptions": {
-    "warnOnUnsupportedTypeScriptVersion": false
-  },
   "ignorePatterns": [
     "*.d.ts",
     "node_modules/",
@@ -46,6 +43,15 @@
     ]
   },
   "overrides": [
+    {
+      "files": ["**/*.ts"],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "warnOnUnsupportedTypeScriptVersion": false,
+        "project": ["./tsconfig.json"]
+      },
+      "rules": {"@typescript-eslint/no-floating-promises": "error"}
+    },
     {
       "files": ["src/server/**"],
       "rules": {
@@ -107,6 +113,13 @@
         "node/no-unpublished-import": "off",
         "no-console": "off",
         "no-process-exit": "off"
+      }
+    },
+    {
+      "files": ["integration/**"],
+      "parserOptions": {
+        "warnOnUnsupportedTypeScriptVersion": false,
+        "project": ["./tsconfig.integration.json"]
       }
     }
   ]

--- a/integration/runTest.ts
+++ b/integration/runTest.ts
@@ -59,4 +59,4 @@ async function main() {
   }
 }
 
-main();
+void main();

--- a/scripts/build-extension.ts
+++ b/scripts/build-extension.ts
@@ -25,7 +25,7 @@ import * as yargs from 'yargs';
 import {doBuild} from './build_common';
 import {outDir, Targets} from './constants';
 
-yargs
+void yargs
   .scriptName('build-extension')
   .usage('$0 <cmd> [args]')
   .command(

--- a/scripts/third_party_licenses.ts
+++ b/scripts/third_party_licenses.ts
@@ -252,4 +252,4 @@ const getLicenses = async () => {
   }
 };
 
-getLicenses();
+void getLicenses();

--- a/src/extension/browser/extension_browser.ts
+++ b/src/extension/browser/extension_browser.ts
@@ -38,10 +38,15 @@ import {editConnectionsCommand} from './commands/edit_connections';
 import {fileHandler} from '../utils/files';
 import {WorkerConnectionBrowser} from './worker_connection_browser';
 import {WorkerGetSecretMessage} from '../../common/types/worker_message_types';
+import {noAwait} from '../../util/no_await';
 let client: LanguageClient;
 
 export function activate(context: vscode.ExtensionContext): void {
-  setupLanguageServer(context);
+  noAwait(asyncActivate(context));
+}
+
+async function asyncActivate(context: vscode.ExtensionContext) {
+  await setupLanguageServer(context);
   const worker = new WorkerConnectionBrowser(context, client, fileHandler);
   setupSubscriptions(context, worker, client);
 
@@ -79,7 +84,7 @@ export function activate(context: vscode.ExtensionContext): void {
             password: true,
           });
           if (secret) {
-            context.secrets.store(key, secret);
+            await context.secrets.store(key, secret);
           }
         }
         return secret;

--- a/src/extension/browser/extension_browser.ts
+++ b/src/extension/browser/extension_browser.ts
@@ -38,14 +38,9 @@ import {editConnectionsCommand} from './commands/edit_connections';
 import {fileHandler} from '../utils/files';
 import {WorkerConnectionBrowser} from './worker_connection_browser';
 import {WorkerGetSecretMessage} from '../../common/types/worker_message_types';
-import {noAwait} from '../../util/no_await';
 let client: LanguageClient;
 
-export function activate(context: vscode.ExtensionContext): void {
-  noAwait(asyncActivate(context));
-}
-
-async function asyncActivate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   await setupLanguageServer(context);
   const worker = new WorkerConnectionBrowser(context, client, fileHandler);
   setupSubscriptions(context, worker, client);

--- a/src/extension/commands/copy_field_path.ts
+++ b/src/extension/commands/copy_field_path.ts
@@ -25,8 +25,10 @@ import * as vscode from 'vscode';
 import {FieldItem} from '../tree_views/schema_view';
 import {quoteIfNecessary} from '../../common/schema';
 
-export function copyFieldPathCommand(item: FieldItem): void {
+export async function copyFieldPathCommand(item: FieldItem): Promise<void> {
   const fieldPath = item.accessPath.map(quoteIfNecessary).join('.');
-  vscode.env.clipboard.writeText(fieldPath);
-  vscode.window.showInformationMessage(`Copied '${fieldPath}' to clipboard`);
+  await vscode.env.clipboard.writeText(fieldPath);
+  await vscode.window.showInformationMessage(
+    `Copied '${fieldPath}' to clipboard`
+  );
 }

--- a/src/extension/commands/copy_to_clipboard.ts
+++ b/src/extension/commands/copy_to_clipboard.ts
@@ -23,7 +23,10 @@
 
 import * as vscode from 'vscode';
 
-export function copyToClipboardCommand(val: string, type: string): void {
-  vscode.env.clipboard.writeText(val);
-  vscode.window.showInformationMessage(`${type} copied to clipboard`);
+export async function copyToClipboardCommand(
+  val: string,
+  type: string
+): Promise<void> {
+  await vscode.env.clipboard.writeText(val);
+  await vscode.window.showInformationMessage(`${type} copied to clipboard`);
 }

--- a/src/extension/commands/goto_definition_from_schema.ts
+++ b/src/extension/commands/goto_definition_from_schema.ts
@@ -24,9 +24,9 @@
 import * as vscode from 'vscode';
 import {DocumentLocation} from '@malloydata/malloy';
 
-export function goToDefinitionFromSchemaCommand(item: {
+export async function goToDefinitionFromSchemaCommand(item: {
   location?: DocumentLocation;
-}): void {
+}): Promise<void> {
   const location = item.location;
   if (location) {
     const pos = new vscode.Position(
@@ -34,6 +34,11 @@ export function goToDefinitionFromSchemaCommand(item: {
       location.range.start.character
     );
     const uri = vscode.Uri.parse(location.url);
-    vscode.commands.executeCommand('editor.action.goToLocations', uri, pos, []);
+    return vscode.commands.executeCommand(
+      'editor.action.goToLocations',
+      uri,
+      pos,
+      []
+    );
   }
 }

--- a/src/extension/commands/preview_from_schema.ts
+++ b/src/extension/commands/preview_from_schema.ts
@@ -26,8 +26,8 @@ import * as vscode from 'vscode';
 export function previewFromSchemaCommand(item: {
   topLevelExplore: string;
   accessPath: string[];
-}): void {
-  vscode.commands.executeCommand(
+}): Thenable<void> {
+  return vscode.commands.executeCommand(
     'malloy.runQuery',
     `run: ${item.topLevelExplore}->{ select: ${[...item.accessPath, '*'].join(
       '.'

--- a/src/extension/commands/run_named_query.ts
+++ b/src/extension/commands/run_named_query.ts
@@ -41,6 +41,4 @@ export async function runNamedQuery(
       name
     );
   }
-
-  return undefined;
 }

--- a/src/extension/commands/run_named_query_from_schema.ts
+++ b/src/extension/commands/run_named_query_from_schema.ts
@@ -23,6 +23,8 @@
 
 import * as vscode from 'vscode';
 
-export function runNamedQueryFromSchemaCommand(item: {name: string}): void {
-  vscode.commands.executeCommand('malloy.runNamedQuery', item.name);
+export async function runNamedQueryFromSchemaCommand(item: {
+  name: string;
+}): Promise<void> {
+  return vscode.commands.executeCommand('malloy.runNamedQuery', item.name);
 }

--- a/src/extension/commands/run_named_sql_block.ts
+++ b/src/extension/commands/run_named_sql_block.ts
@@ -21,16 +21,20 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {ResultJSON} from '@malloydata/malloy';
 import {WorkerConnection} from '../worker_connection';
 import {
   getActiveDocumentMetadata,
   runMalloyQueryWithProgress,
 } from './utils/run_query_utils';
 
-export function runNamedSQLBlock(worker: WorkerConnection, name: string): void {
+export async function runNamedSQLBlock(
+  worker: WorkerConnection,
+  name: string
+): Promise<ResultJSON | undefined> {
   const documentMeta = getActiveDocumentMetadata();
   if (documentMeta) {
-    runMalloyQueryWithProgress(
+    return runMalloyQueryWithProgress(
       worker,
       {type: 'named_sql', name, documentMeta},
       `${documentMeta.uri} ${name}`,

--- a/src/extension/commands/run_query.ts
+++ b/src/extension/commands/run_query.ts
@@ -48,6 +48,4 @@ export async function runQueryCommand(
       {defaultTab}
     );
   }
-
-  return undefined;
 }

--- a/src/extension/commands/run_query_file.ts
+++ b/src/extension/commands/run_query_file.ts
@@ -45,6 +45,4 @@ export async function runQueryFileCommand(
       documentMeta.fileName.split('/').pop() || documentMeta.fileName
     );
   }
-
-  return undefined;
 }

--- a/src/extension/commands/run_turtle_from_schema.ts
+++ b/src/extension/commands/run_turtle_from_schema.ts
@@ -26,8 +26,8 @@ import * as vscode from 'vscode';
 export function runTurtleFromSchemaCommand(item: {
   topLevelExplore: string;
   accessPath: string[];
-}): void {
-  vscode.commands.executeCommand(
+}): Thenable<void> {
+  return vscode.commands.executeCommand(
     'malloy.runQuery',
     `run: ${item.topLevelExplore}->${item.accessPath.join('.')}`,
     `${item.topLevelExplore}->${item.accessPath.join('.')}`

--- a/src/extension/commands/show_schema_file.ts
+++ b/src/extension/commands/show_schema_file.ts
@@ -21,6 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {ResultJSON} from '@malloydata/malloy';
 import {WorkerConnection} from '../worker_connection';
 import {
   getActiveDocumentMetadata,
@@ -28,15 +29,15 @@ import {
   runMalloyQueryWithProgress,
 } from './utils/run_query_utils';
 
-export function showSchemaFileCommand(
+export async function showSchemaFileCommand(
   worker: WorkerConnection,
   uri?: string
-): void {
+): Promise<ResultJSON | undefined> {
   const documentMeta = uri
     ? getDocumentMetadataFromUri(uri)
     : getActiveDocumentMetadata();
   if (documentMeta) {
-    runMalloyQueryWithProgress(
+    return runMalloyQueryWithProgress(
       worker,
       {type: 'file', index: -1, documentMeta},
       documentMeta.uri,

--- a/src/extension/commands/show_sql.ts
+++ b/src/extension/commands/show_sql.ts
@@ -21,20 +21,21 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {ResultJSON} from '@malloydata/malloy';
 import {WorkerConnection} from '../worker_connection';
 import {
   getActiveDocumentMetadata,
   runMalloyQueryWithProgress,
 } from './utils/run_query_utils';
 
-export function showSQLCommand(
+export async function showSQLCommand(
   worker: WorkerConnection,
   query: string,
   name?: string
-): void {
+): Promise<ResultJSON | undefined> {
   const documentMeta = getActiveDocumentMetadata();
   if (documentMeta) {
-    runMalloyQueryWithProgress(
+    return runMalloyQueryWithProgress(
       worker,
       {type: 'string', text: query, documentMeta},
       `${documentMeta.uri} ${name}`,

--- a/src/extension/commands/show_sql_file.ts
+++ b/src/extension/commands/show_sql_file.ts
@@ -21,19 +21,20 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {ResultJSON} from '@malloydata/malloy';
 import {WorkerConnection} from '../worker_connection';
 import {
   getActiveDocumentMetadata,
   runMalloyQueryWithProgress,
 } from './utils/run_query_utils';
 
-export function showSQLFileCommand(
+export async function showSQLFileCommand(
   worker: WorkerConnection,
   queryIndex = -1
-): void {
+): Promise<ResultJSON | undefined> {
   const documentMeta = getActiveDocumentMetadata();
   if (documentMeta) {
-    runMalloyQueryWithProgress(
+    return runMalloyQueryWithProgress(
       worker,
       {type: 'file', index: queryIndex, documentMeta},
       documentMeta.uri,

--- a/src/extension/commands/show_sql_named_query.ts
+++ b/src/extension/commands/show_sql_named_query.ts
@@ -21,19 +21,20 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+import {ResultJSON} from '@malloydata/malloy';
 import {WorkerConnection} from '../worker_connection';
 import {
   getActiveDocumentMetadata,
   runMalloyQueryWithProgress,
 } from './utils/run_query_utils';
 
-export function showSQLNamedQueryCommand(
+export async function showSQLNamedQueryCommand(
   worker: WorkerConnection,
   name: string
-): void {
+): Promise<ResultJSON | undefined> {
   const documentMeta = getActiveDocumentMetadata();
   if (documentMeta) {
-    runMalloyQueryWithProgress(
+    return runMalloyQueryWithProgress(
       worker,
       {type: 'named', name, documentMeta},
       `${documentMeta.uri} ${name}`,

--- a/src/extension/commands/utils/vscode_utils.ts
+++ b/src/extension/commands/utils/vscode_utils.ts
@@ -113,12 +113,13 @@ export function showSchemaTreeViewWhenFocused(
   });
 
   panel.onDidChangeViewState(
-    (e: vscode.WebviewPanelOnDidChangeViewStateEvent) => {
-      vscode.commands.executeCommand(
-        'setContext',
-        'malloy.webviewPanelFocused',
-        e.webviewPanel.active
-      );
-    }
+    (e: vscode.WebviewPanelOnDidChangeViewStateEvent) =>
+      noAwait(
+        vscode.commands.executeCommand(
+          'setContext',
+          'malloy.webviewPanelFocused',
+          e.webviewPanel.active
+        )
+      )
   );
 }

--- a/src/extension/connection_config_manager.ts
+++ b/src/extension/connection_config_manager.ts
@@ -27,6 +27,7 @@ import {
   ConnectionConfigManager,
   ExternalConnectionConfig,
 } from '../common/types/connection_manager_types';
+import {noAwait} from '../util/no_await';
 import {getMalloyConfig} from './utils/config';
 
 const getConnectionsConfig = (): ConnectionConfig[] => {
@@ -42,7 +43,7 @@ export abstract class ConnectionConfigManagerBase
   private configList: ConnectionConfig[] = [];
 
   constructor() {
-    this.onConfigurationUpdated();
+    noAwait(this.onConfigurationUpdated());
   }
 
   public abstract getAvailableBackends(): ConnectionBackend[];

--- a/src/extension/connection_editor.ts
+++ b/src/extension/connection_editor.ts
@@ -83,13 +83,13 @@ export class EditConnectionPanel {
           const malloyConfig = getMalloyConfig();
           const hasWorkspaceConfig =
             malloyConfig.inspect('connections')?.workspaceValue !== undefined;
-          malloyConfig.update(
+          await malloyConfig.update(
             'connections',
             connections,
             vscode.ConfigurationTarget.Global
           );
           if (hasWorkspaceConfig) {
-            malloyConfig.update(
+            await malloyConfig.update(
               'connections',
               connections,
               vscode.ConfigurationTarget.Workspace

--- a/src/extension/node/extension_node.ts
+++ b/src/extension/node/extension_node.ts
@@ -42,7 +42,6 @@ import {MALLOY_EXTENSION_STATE} from '../state';
 import {WorkerConnectionNode} from './worker_connection_node';
 import {WorkerGetSecretMessage} from '../../common/types/worker_message_types';
 import {deletePassword, getPassword} from 'keytar';
-import {noAwait} from '../../util/no_await';
 
 let client: LanguageClient;
 
@@ -59,11 +58,7 @@ const cloudCodeEnv = () => {
   }
 };
 
-export function activate(context: vscode.ExtensionContext): void {
-  noAwait(asyncActivate(context));
-}
-
-async function asyncActivate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   cloudCodeEnv();
   await setupLanguageServer(context);
   const worker = new WorkerConnectionNode(context, client, fileHandler);

--- a/src/extension/node/extension_node.ts
+++ b/src/extension/node/extension_node.ts
@@ -42,6 +42,7 @@ import {MALLOY_EXTENSION_STATE} from '../state';
 import {WorkerConnectionNode} from './worker_connection_node';
 import {WorkerGetSecretMessage} from '../../common/types/worker_message_types';
 import {deletePassword, getPassword} from 'keytar';
+import {noAwait} from '../../util/no_await';
 
 let client: LanguageClient;
 
@@ -59,8 +60,12 @@ const cloudCodeEnv = () => {
 };
 
 export function activate(context: vscode.ExtensionContext): void {
+  noAwait(asyncActivate(context));
+}
+
+async function asyncActivate(context: vscode.ExtensionContext) {
   cloudCodeEnv();
-  setupLanguageServer(context);
+  await setupLanguageServer(context);
   const worker = new WorkerConnectionNode(context, client, fileHandler);
   setupSubscriptions(context, worker, client);
   const connectionsTree = new ConnectionsProvider(
@@ -105,7 +110,7 @@ export function activate(context: vscode.ExtensionContext): void {
           key
         );
         if (value) {
-          deletePassword('com.malloy-lang.vscode-extension', key);
+          await deletePassword('com.malloy-lang.vscode-extension', key);
           await context.secrets.store(key, value);
         }
         let secret = await context.secrets.get(key);
@@ -116,7 +121,7 @@ export function activate(context: vscode.ExtensionContext): void {
             password: true,
           });
           if (secret) {
-            context.secrets.store(key, secret);
+            await context.secrets.store(key, secret);
           }
         }
         return secret;

--- a/src/extension/notebook/malloy_controller.ts
+++ b/src/extension/notebook/malloy_controller.ts
@@ -119,7 +119,7 @@ export function activateNotebookController(
 
   const relayEvent = (event: MessageEvent) => {
     const {command, args} = event.message;
-    vscode.commands.executeCommand(command, ...args);
+    noAwait(vscode.commands.executeCommand(command, ...args));
   };
   context.subscriptions.push(
     vscode.notebooks

--- a/src/extension/subscriptions.ts
+++ b/src/extension/subscriptions.ts
@@ -226,7 +226,7 @@ export const setupSubscriptions = (
     context.globalState.get('malloy_client_id');
   if (clientId === undefined) {
     clientId = getNewClientId();
-    context.globalState.update('malloy_client_id', clientId);
+    noAwait(context.globalState.update('malloy_client_id', clientId));
   }
   MALLOY_EXTENSION_STATE.setClientId(clientId);
 

--- a/src/extension/utils/config.ts
+++ b/src/extension/utils/config.ts
@@ -27,6 +27,7 @@ import {
   ConnectionBackend,
   ConnectionConfig,
 } from '../../common/types/connection_manager_types';
+import {noAwait} from '../../util/no_await';
 
 /**
  * Centralized place to pull configuration for Malloy extension
@@ -58,16 +59,20 @@ export const getMalloyConfig = (): vscode.WorkspaceConfiguration => {
         const hasWorkspaceConfig =
           malloyConfig.inspect('connections')?.workspaceValue !== undefined;
 
-        malloyConfig.update(
-          'connections',
-          connectionConfigs,
-          vscode.ConfigurationTarget.Global
-        );
-        if (hasWorkspaceConfig) {
+        noAwait(
           malloyConfig.update(
             'connections',
             connectionConfigs,
-            vscode.ConfigurationTarget.Workspace
+            vscode.ConfigurationTarget.Global
+          )
+        );
+        if (hasWorkspaceConfig) {
+          noAwait(
+            malloyConfig.update(
+              'connections',
+              connectionConfigs,
+              vscode.ConfigurationTarget.Workspace
+            )
           );
         }
       }

--- a/src/extension/webview_message_manager.ts
+++ b/src/extension/webview_message_manager.ts
@@ -22,6 +22,7 @@
  */
 
 import {WebviewPanel, WebviewView} from 'vscode';
+import {noAwait} from '../util/no_await';
 
 export class WebviewMessageManager<T> {
   constructor(private panel: WebviewPanel | WebviewView) {
@@ -51,7 +52,7 @@ export class WebviewMessageManager<T> {
 
   public postMessage(message: T): void {
     if (this.canSendMessages) {
-      this.panel.webview.postMessage(message);
+      noAwait(this.panel.webview.postMessage(message));
     } else {
       this.pendingMessages.push(message);
     }
@@ -63,7 +64,7 @@ export class WebviewMessageManager<T> {
 
   private flushPendingMessages() {
     this.pendingMessages.forEach(message => {
-      this.panel.webview.postMessage(message);
+      noAwait(this.panel.webview.postMessage(message));
     });
     this.pendingMessages.splice(0, this.pendingMessages.length);
   }

--- a/src/extension/webviews/query_page/download_form.ts
+++ b/src/extension/webviews/query_page/download_form.ts
@@ -165,7 +165,7 @@ export class DownloadForm extends LitElement {
 
   copyToClipboard = async () => {
     const options = await this.createTextBlob();
-    this.onCopy(options);
+    await this.onCopy(options);
   };
 
   override render() {

--- a/src/extension/webviews/query_page/query_page.ts
+++ b/src/extension/webviews/query_page/query_page.ts
@@ -334,7 +334,8 @@ export class QueryPage extends LitElement {
               ...this.results,
               html,
             };
-          });
+          })
+          .catch(console.error);
       }
     }
   };

--- a/src/server/init.ts
+++ b/src/server/init.ts
@@ -118,7 +118,7 @@ export const initServer = (
           versionAtRequest === undefined ||
           versionAtRequest === document.version
         ) {
-          connection.sendDiagnostics({
+          await connection.sendDiagnostics({
             uri,
             diagnostics: diagnostics[uri],
             version: documents.get(uri)?.version,
@@ -140,7 +140,7 @@ export const initServer = (
               connection.console.info(
                 `diagnoseDocument ejecting ${document.uri}`
               );
-              debouncedDiagnoseDocuments[key](document);
+              debouncedDiagnoseDocument(document);
             }
           }
         }
@@ -159,7 +159,7 @@ export const initServer = (
     if (!debouncedDiagnoseDocuments[uri]) {
       debouncedDiagnoseDocuments[uri] = debounce(diagnoseDocument, 300);
     }
-    debouncedDiagnoseDocuments[uri](document);
+    debouncedDiagnoseDocuments[uri](document)?.catch(console.error);
   };
 
   documents.onDidChangeContent(change => {

--- a/src/util/no_await.ts
+++ b/src/util/no_await.ts
@@ -21,4 +21,7 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-export function noAwait(_: unknown) {}
+export function noAwait(x: Thenable<unknown>) {
+  // Avoid unhandled exceptions
+  x.then(() => {}, console.error);
+}

--- a/src/worker/node/download_query.ts
+++ b/src/worker/node/download_query.ts
@@ -36,6 +36,7 @@ import {
   QueryDownloadMessage,
   QueryDownloadStatus,
 } from '../../common/types/message_types';
+import {noAwait} from '../../util/no_await';
 
 export async function downloadQuery(
   messageHandler: WorkerMessageHandler,
@@ -51,7 +52,7 @@ export async function downloadQuery(
   const sendMessage = (message: QueryDownloadMessage) => {
     console.debug('sendMessage', panelId, message.status);
     const progress = new ProgressType<QueryDownloadMessage>();
-    messageHandler.sendProgress(progress, panelId, message);
+    noAwait(messageHandler.sendProgress(progress, panelId, message));
   };
 
   const url = new URL(uri);

--- a/src/worker/run_query.ts
+++ b/src/worker/run_query.ts
@@ -47,6 +47,7 @@ import {Cell, CellData, FileHandler} from '../common/types/file_handler';
 import {CancellationToken, ProgressType} from 'vscode-jsonrpc';
 import {errorMessage} from '../common/errors';
 import {fixLogRange} from '../common/malloy_sql';
+import {noAwait} from '../util/no_await';
 
 interface StructDefSuccess {
   structDef: StructDef;
@@ -118,7 +119,7 @@ const runMSQLCell = async (
   const sendMessage = (message: QueryMessageStatus) => {
     const progress = new ProgressType<QueryMessageStatus>();
     console.debug('sendMessage', panelId, message.status);
-    messageHandler.sendProgress(progress, panelId, message);
+    noAwait(messageHandler.sendProgress(progress, panelId, message));
   };
 
   const {
@@ -263,7 +264,7 @@ export const runQuery = async (
   const sendMessage = (message: QueryMessageStatus) => {
     console.debug('sendMessage', panelId, message.status);
     const progress = new ProgressType<QueryMessageStatus>();
-    messageHandler.sendProgress(progress, panelId, message);
+    noAwait(messageHandler.sendProgress(progress, panelId, message));
   };
 
   const abortController = new AbortController();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "node",
     "noEmit": true,
     "resolveJsonModule": true,
-    "rootDir": "src",
     "skipLibCheck": true,
     "target": "es2019",
     "lib": ["es2021"],
@@ -14,6 +13,6 @@
     "noImplicitOverride": true,
     "strict": true
   },
-  "include": ["./src"],
+  "include": ["./src", "./scripts", "./test"],
   "exclude": ["node_modules", ".vscode-test", ".vscode-test-web", "dist"]
 }


### PR DESCRIPTION
Finally enabled the no floating promises linter rule, and deal with the fallout. Makes `noAwait()` safer. I'm not sure that all uses of `noAwait()` are ideal, but `noAwait()` now catches and logs errors, leaving us in a slightly better position than we were previously.