### PR TITLE
Add command to create default connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,6 +175,11 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "malloy.createDefaultConnections",
+        "title": "Create Default Connections",
+        "category": "Malloy"
+      },
+      {
         "command": "malloy.editConnections",
         "title": "Edit Connections",
         "category": "Malloy"

--- a/src/extension/browser/extension_browser.ts
+++ b/src/extension/browser/extension_browser.ts
@@ -42,7 +42,7 @@ let client: LanguageClient;
 export async function activate(context: vscode.ExtensionContext) {
   await setupLanguageServer(context);
   const worker = new WorkerConnectionBrowser(context, client, fileHandler);
-  setupSubscriptions(context, worker, client);
+  await setupSubscriptions(context, worker, client);
 
   const connectionsTree = new ConnectionsProvider(
     context,

--- a/src/extension/commands/create_default_connections.ts
+++ b/src/extension/commands/create_default_connections.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import * as vscode from 'vscode';
+import {getMalloyConfig} from '../utils/config';
+import {
+  ConnectionBackend,
+  ConnectionConfig,
+} from '../../common/types/connection_manager_types';
+
+/**
+ * Create the default connections, duckdb, bigquery and motherduck (md)
+ * If force is true, all connections are recreated if they are missing,
+ * if false, only connections that have not been created before are
+ * created.
+ *
+ * @param context VS Code extension context
+ * @param force Re-create if the user has created and deleted
+ */
+export async function createDefaultConnections(
+  context: vscode.ExtensionContext,
+  force = true
+): Promise<void> {
+  const malloyConfig = getMalloyConfig();
+  const connectionConfigs = malloyConfig.get(
+    'connections'
+  ) as ConnectionConfig[];
+  for (const defaultConnection of DEFAULT_CONNECTIONS) {
+    if (
+      !connectionConfigs.find(
+        connection => connection.name === defaultConnection.name
+      )
+    ) {
+      const key = `malloy_created_default.${defaultConnection.name}`;
+      const alreadyCreated = context.globalState.get(key);
+      if (force || !alreadyCreated) {
+        connectionConfigs.push(defaultConnection);
+        await context.globalState.update(key, true);
+      }
+    }
+  }
+  await malloyConfig.update('connections', connectionConfigs, true);
+}
+
+const DEFAULT_CONNECTIONS: ConnectionConfig[] = [
+  {
+    name: 'bigquery',
+    backend: ConnectionBackend.BigQuery,
+    id: 'bigquery-default',
+  },
+  {
+    name: 'duckdb',
+    backend: ConnectionBackend.DuckDB,
+    id: 'duckdb-default',
+  },
+  {
+    name: 'md',
+    backend: ConnectionBackend.DuckDB,
+    id: 'motherduck-default',
+    databasePath: 'md:',
+  },
+] as const;

--- a/src/extension/node/extension_node.ts
+++ b/src/extension/node/extension_node.ts
@@ -60,7 +60,7 @@ export async function activate(context: vscode.ExtensionContext) {
   cloudCodeEnv();
   await setupLanguageServer(context);
   const worker = new WorkerConnectionNode(context, client, fileHandler);
-  setupSubscriptions(context, worker, client);
+  await setupSubscriptions(context, worker, client);
   const connectionsTree = new ConnectionsProvider(
     context,
     connectionConfigManager

--- a/src/extension/subscriptions.ts
+++ b/src/extension/subscriptions.ts
@@ -65,12 +65,13 @@ import {WorkerConnection} from './worker_connection';
 import {runQueryAtCursorCommand} from './commands/run_query_at_cursor';
 import {showSchemaFileCommand} from './commands/show_schema_file';
 import {noAwait} from '../util/no_await';
+import {createDefaultConnections} from './commands/create_default_connections';
 
 function getNewClientId(): string {
   return uuid();
 }
 
-export const setupSubscriptions = (
+export const setupSubscriptions = async (
   context: vscode.ExtensionContext,
   worker: WorkerConnection,
   client: BaseLanguageClient
@@ -230,6 +231,19 @@ export const setupSubscriptions = (
     noAwait(context.globalState.update('malloy_client_id', clientId));
   }
   MALLOY_EXTENSION_STATE.setClientId(clientId);
+
+  // Connection Defaults
+  context.globalState.setKeysForSync(['malloy_created_default']);
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      'malloy.createDefaultConnections',
+      (force: boolean) => createDefaultConnections(context, force)
+    )
+  );
+  await vscode.commands.executeCommand(
+    'malloy.createDefaultConnections',
+    false
+  );
 
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument(async e => {

--- a/src/server/init.ts
+++ b/src/server/init.ts
@@ -219,6 +219,7 @@ export const initServer = (
       (change?.settings as any)?.malloy?.connections ?? []
     );
     haveConnectionsBeenSet = true;
+    translateCache.cache.clear();
     documents.all().forEach(debouncedDiagnoseDocument);
   });
 


### PR DESCRIPTION
Create a command that creates all the normal Malloy default connections: bigquery, duckdb and motherduck. Keeps track of created connections and does not re-create connections unless the command is explicitly called. 

Also fixes a bug where connection settings updates were not forcing document re-evaluation.