### PR TITLE
Shim document for motherduck wasm

### DIFF
--- a/src/server/browser/server_browser.ts
+++ b/src/server/browser/server_browser.ts
@@ -39,5 +39,14 @@ const connectionManager = new ConnectionManager(
   new WebConnectionFactory(connection)
 );
 
+interface DocumentShim {
+  document: unknown;
+}
+
+// Hack to support the MotherDuck wasm bundle which uses document.postMessage()
+if (typeof globalThis !== 'undefined' && typeof document === 'undefined') {
+  (globalThis as DocumentShim).document = globalThis;
+}
+
 initServer(connection, connectionManager);
 new MessageHandler(connection, connectionManager);


### PR DESCRIPTION
The current motherduck wasm bundle uses `document.postMessage()`, which doesn't exist in the WebWorker we're using it under. This just maps `globalThis` to `document` so that `document.postMessage()` is available.