### PR TITLE
Allow specifying a node runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -381,6 +381,10 @@
           "description": "Whether telemetry is enabled for the Malloy extension. Used in conjunction with the `telemetry.telemetryLevel` setting and the --disable-telemetry CLI flag.",
           "default": true
         },
+        "malloy.nodePath": {
+          "type": "string",
+          "description": "Path to a Node.js executable to use for running the language server. Set this option if you're having trouble with Malloy running out of memory. Node version >= 20 recommended."
+        },
         "malloy.connections": {
           "type": "array",
           "items": {

--- a/src/extension/node/extension_node.ts
+++ b/src/extension/node/extension_node.ts
@@ -112,12 +112,17 @@ async function setupLanguageServer(
     ],
   };
 
+  const runtime = vscode.workspace
+    .getConfiguration('malloy')
+    .get<string>('nodePath');
+
   const serverOptions: ServerOptions = {
-    run: {module: serverModule, transport: TransportKind.ipc},
+    run: {module: serverModule, transport: TransportKind.ipc, runtime},
     debug: {
       module: serverModule,
       transport: TransportKind.ipc,
       options: debugOptions,
+      runtime,
     },
   };
 


### PR DESCRIPTION
Allow spawning the language server using an external node process, which will generally have access to more memory than the electron runtime.