### PR TITLE
Add refresh to explore

### DIFF
--- a/src/common/types/message_types.ts
+++ b/src/common/types/message_types.ts
@@ -324,6 +324,7 @@ export type ComposerMessage =
 export enum ComposerPageMessageType {
   Ready = 'ready',
   RunQuery = 'run-query',
+  RefreshModel = 'refresh-model',
 }
 
 export interface ComposerPageMessageReady {
@@ -337,6 +338,12 @@ export interface ComposerPageMessageRunQuery {
   queryName: string;
 }
 
+export interface ComposerPageMessageRefreshModel {
+  type: ComposerPageMessageType.RefreshModel;
+  query: string;
+}
+
 export type ComposerPageMessage =
   | ComposerPageMessageReady
-  | ComposerPageMessageRunQuery;
+  | ComposerPageMessageRunQuery
+  | ComposerPageMessageRefreshModel;

--- a/src/common/types/worker_message_types.ts
+++ b/src/common/types/worker_message_types.ts
@@ -40,6 +40,7 @@ import {ModelDef} from '@malloydata/malloy';
 
 export interface MessageCompile {
   documentMeta: DocumentMetadata;
+  query?: string;
 }
 
 export interface MessageRun {

--- a/src/extension/webviews/composer_page/App.tsx
+++ b/src/extension/webviews/composer_page/App.tsx
@@ -107,6 +107,15 @@ export const App: React.FC<AppProps> = ({vscode}) => {
     [vscode]
   );
 
+  const refreshModel = React.useCallback(
+    (query: string) =>
+      vscode.postMessage({
+        type: ComposerPageMessageType.RefreshModel,
+        query,
+      }),
+    [vscode]
+  );
+
   if (documentMeta && modelDef && sourceName) {
     return (
       <div style={{height: '100%'}}>
@@ -116,6 +125,7 @@ export const App: React.FC<AppProps> = ({vscode}) => {
           sourceName={sourceName}
           viewName={viewName}
           runQuery={runQuery}
+          refreshModel={refreshModel}
           topValues={topValues}
         />
       </div>

--- a/src/extension/webviews/composer_page/Composer.tsx
+++ b/src/extension/webviews/composer_page/Composer.tsx
@@ -23,6 +23,7 @@ export interface ComposerProps {
   sourceName: string;
   viewName?: string;
   runQuery: RunQuery;
+  refreshModel: (query: string) => void;
   topValues: SearchValueMapResult[] | undefined;
 }
 
@@ -34,11 +35,13 @@ export const Composer: React.FC<ComposerProps> = ({
   sourceName,
   viewName,
   runQuery: runQueryImp,
+  refreshModel,
   topValues,
 }) => {
   const [error, setError] = useState<Error>();
   const {
     error: queryError,
+    query,
     queryMalloy,
     queryName,
     queryModifiers,
@@ -89,6 +92,7 @@ export const Composer: React.FC<ComposerProps> = ({
         result={result || error}
         isRunning={isRunning}
         runQuery={runQuery}
+        refreshModel={() => refreshModel(query)}
       />
     </>
   );

--- a/src/worker/compile_query.ts
+++ b/src/worker/compile_query.ts
@@ -14,7 +14,8 @@ import {ModelDef, Runtime} from '@malloydata/malloy';
 export const compileQuery = async (
   fileHandler: FileHandler,
   connectionManager: ConnectionManager,
-  documentMeta: DocumentMetadata
+  documentMeta: DocumentMetadata,
+  query?: string
 ): Promise<ModelDef | undefined> => {
   const {uri} = documentMeta;
   const url = new URL(uri);
@@ -38,6 +39,10 @@ export const compileQuery = async (
     cellData,
     workspaceFolders
   );
+
+  if (query && modelMaterializer) {
+    await modelMaterializer.loadQuery(query).getPreparedQuery();
+  }
 
   const model = await modelMaterializer?.getModel();
   return model?._modelDef;

--- a/src/worker/message_handler.ts
+++ b/src/worker/message_handler.ts
@@ -47,8 +47,8 @@ export class MessageHandler implements WorkerMessageHandler {
   ) {
     this.fileHandler = new RpcFileHandler(this);
 
-    this.onRequest('malloy/compile', message =>
-      compileQuery(this.fileHandler, connectionManager, message.documentMeta)
+    this.onRequest('malloy/compile', ({documentMeta, query}) =>
+      compileQuery(this.fileHandler, connectionManager, documentMeta, query)
     );
 
     this.onRequest('malloy/run', (message, cancellationToken) =>


### PR DESCRIPTION
Adds a refresh button that re-syncs the model from being explored. Fails if the model does not currently compile, or the query being explored does not compile under the new model.