### PR TITLE
Fix overflow scrolling in connection editor

### DIFF
--- a/src/extension/webviews/connections_page/ConnectionsApp.tsx
+++ b/src/extension/webviews/connections_page/ConnectionsApp.tsx
@@ -132,7 +132,7 @@ export const ConnectionsApp = ({vscode}: ConnectionsAppProp) => {
       <VSCodeProgressRing>Loading</VSCodeProgressRing>
     </div>
   ) : (
-    <div style={{maxWidth: '80em'}}>
+    <div style={{maxWidth: '80em', height: '100%', overflowY: 'auto'}}>
       <div style={{margin: '0 10px 10px 10px'}}>
         <ConnectionEditorList
           connections={connections}


### PR DESCRIPTION
Add a small amount of CSS to enable vertical scrolling in the connection editor, when the panel is smaller than the content.

Fixes https://github.com/malloydata/malloy-vscode-extension/issues/596

https://github.com/user-attachments/assets/6fdcded1-1ef4-40b6-a3e6-3f546af5acfc

