### PR TITLE
Decouple schema and preview lenses

### DIFF
--- a/src/common/types/query_spec.ts
+++ b/src/common/types/query_spec.ts
@@ -42,7 +42,8 @@ export interface QueryStringSpec {
 
 export interface QueryFileSpec {
   type: 'file';
-  index: number;
+  index?: number;
+  exploreName?: string;
   documentMeta: DocumentMetadata;
 }
 

--- a/src/extension/commands/preview_from_schema.ts
+++ b/src/extension/commands/preview_from_schema.ts
@@ -32,7 +32,7 @@ export function previewFromSchemaCommand(item: {
     `run: ${item.topLevelExplore}->{ select: ${[...item.accessPath, '*'].join(
       '.'
     )}; limit: 20 }`,
-    `Preview ${item.topLevelExplore} ${item.accessPath.join('.')}`,
+    `Preview: ${item.topLevelExplore} ${item.accessPath.join('.')}`,
     'preview'
   );
 }

--- a/src/extension/commands/show_schema.ts
+++ b/src/extension/commands/show_schema.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {WorkerConnection} from '../worker_connection';
+import {
+  getActiveDocumentMetadata,
+  runMalloyQueryWithProgress,
+} from './utils/run_query_utils';
+import {RunMalloyQueryResult} from '../../common/types/message_types';
+
+export async function showSchemaCommand(
+  worker: WorkerConnection,
+  exploreName: string
+): Promise<RunMalloyQueryResult | undefined> {
+  const documentMeta = getActiveDocumentMetadata();
+  if (documentMeta) {
+    return runMalloyQueryWithProgress(
+      worker,
+      {type: 'file', exploreName, documentMeta},
+      documentMeta.uri,
+      `Schema: ${exploreName}`,
+      {showSchemaOnly: true}
+    );
+  }
+  return undefined;
+}

--- a/src/extension/notebook/renderer/schema_entry.tsx
+++ b/src/extension/notebook/renderer/schema_entry.tsx
@@ -114,7 +114,7 @@ export function SchemaRendererWrapper({
     const select = fieldPath.join('.');
     const args = [
       `run: ${exploreName}->{ select: ${select}; limit: 20 }`,
-      `Preview ${exploreName} ${accessPath}`,
+      `Preview: ${exploreName} ${accessPath}`,
       'preview',
     ];
     postMessage?.({command, args});

--- a/src/extension/subscriptions.ts
+++ b/src/extension/subscriptions.ts
@@ -66,6 +66,7 @@ import {showSchemaFileCommand} from './commands/show_schema_file';
 import {noAwait} from '../util/no_await';
 import {createDefaultConnections} from './commands/create_default_connections';
 import {openComposer} from './commands/open_composer';
+import {showSchemaCommand} from './commands/show_schema';
 
 function getNewClientId(): string {
   return uuid();
@@ -122,6 +123,13 @@ export const setupSubscriptions = async (
   context.subscriptions.push(
     vscode.commands.registerCommand('malloy.showSchemaFile', (uri: string) =>
       showSchemaFileCommand(worker, uri)
+    )
+  );
+
+  // Show Schema (source)
+  context.subscriptions.push(
+    vscode.commands.registerCommand('malloy.showSchema', (explore: string) =>
+      showSchemaCommand(worker, explore)
     )
   );
 

--- a/src/server/lenses/lenses.ts
+++ b/src/server/lenses/lenses.ts
@@ -149,20 +149,14 @@ export async function getMalloyLenses(
         {
           const children = symbol.children;
           const exploreName = symbol.name;
-          if (!externalPreview) {
-            lenses.push({
-              range: symbol.lensRange.toJSON(),
-              command: {
-                title: 'Schema',
-                command: 'malloy.runQuery',
-                arguments: [
-                  `run: ${exploreName}->{ select: *; limit: 20 }`,
-                  `Preview ${exploreName}`,
-                  'schema',
-                ],
-              },
-            });
-          }
+          lenses.push({
+            range: symbol.lensRange.toJSON(),
+            command: {
+              title: 'Schema',
+              command: 'malloy.showSchema',
+              arguments: [unquoteIdentifier(exploreName)],
+            },
+          });
           lenses.push({
             range: symbol.lensRange.toJSON(),
             command: {
@@ -179,7 +173,7 @@ export async function getMalloyLenses(
                 command: 'malloy.runQuery',
                 arguments: [
                   `run: ${exploreName}->{ select: *; limit: 20 }`,
-                  `Preview ${exploreName}`,
+                  `Preview: ${exploreName}`,
                   'preview',
                 ],
               },
@@ -250,22 +244,15 @@ export async function getMalloyLenses(
               arguments: [url.toString()],
             },
           });
-          if (!externalPreview) {
-            for (const child of symbol.children) {
-              lenses.push({
-                range: child.lensRange.toJSON(),
-                command: {
-                  title: child.name,
-                  command: 'malloy.runQuery',
-                  arguments: [
-                    `run: ${child.name}->{ select: *; limit: 20 }`,
-                    `Preview ${child.name}`,
-                    'schema',
-                    symbol.name,
-                  ],
-                },
-              });
-            }
+          for (const child of symbol.children) {
+            lenses.push({
+              range: child.lensRange.toJSON(),
+              command: {
+                title: child.name,
+                command: 'malloy.showSchema',
+                arguments: [child.name],
+              },
+            });
           }
           symbol.children.forEach((child, idx) => {
             lenses.push({

--- a/src/worker/create_runnable.ts
+++ b/src/worker/create_runnable.ts
@@ -96,7 +96,7 @@ export const createRunnable = async (
       runnable = mm.loadQueryByName(query.name);
       break;
     case 'file': {
-      if (query.index === -1) {
+      if (query.index === undefined || query.index === -1) {
         runnable = mm.loadFinalQuery();
       } else {
         runnable = mm.loadQueryByIndex(query.index);

--- a/src/worker/run_query.ts
+++ b/src/worker/run_query.ts
@@ -350,10 +350,19 @@ export const runQuery = async (
       );
       const model = await modelMaterializer?.getModel();
       if (model) {
-        sendMessage({
-          status: QueryRunStatus.Schema,
-          schema: model.explores.map(explore => explore.toJSON()),
-        });
+        if (query.type === 'file' && query.exploreName) {
+          sendMessage({
+            status: QueryRunStatus.Schema,
+            schema: model.explores
+              .filter(explore => explore.name === query.exploreName)
+              .map(explore => explore.toJSON()),
+          });
+        } else {
+          sendMessage({
+            status: QueryRunStatus.Schema,
+            schema: model.explores.map(explore => explore.toJSON()),
+          });
+        }
       }
       return;
     }


### PR DESCRIPTION
For simplicity when the Schema lens was introduced it was tied to the Preview lens. This breaks that connection so that with connections where we link out to Preview (like BigQuery) the schema view is still available.