### PR TITLE
Fix: Restore snowflake privateKeyPass from secrets on editor reload

### DIFF
--- a/src/extension/connection_editor.ts
+++ b/src/extension/connection_editor.ts
@@ -194,6 +194,14 @@ export class EditConnectionPanel {
           motherDuckToken,
         };
       }
+      if ('privateKeyPass' in connection && connection.privateKeyPass) {
+        const key = `connections.${connection.id}.privateKeyPass`;
+        const privateKeyPass = await this.context.secrets.get(key);
+        connection = {
+          ...connection,
+          privateKeyPass,
+        };
+      }
       modifiedConnections.push(connection);
     }
     return modifiedConnections;


### PR DESCRIPTION
Adds missing secret retrieval logic in handleConnectionsPreLoad for Snowflake privateKeyPass fields to prevent them from being lost when reopening the connection editor