### PR TITLE
fix: malloy-link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,10 @@
       },
       "devDependencies": {
         "@chialab/esbuild-plugin-worker": "^0.18.1",
+        "@duckdb/node-api": "^1.4.3-r.2",
         "@jest/globals": "^26.6.2",
+        "@malloydata/malloy-filter": "0.0.334",
+        "@malloydata/malloy-tag": "0.0.334",
         "@types/jest": "^29.2.1",
         "@types/jsdom": "^16.2.11",
         "@types/lodash": "^4.14.191",
@@ -2367,34 +2370,37 @@
       }
     },
     "node_modules/@duckdb/node-api": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.4.3-r.1.tgz",
-      "integrity": "sha512-/L6nywAWDnMptERJiO3npCu8XqWYGSo2prw6RvxERtjT9J95cnUP+WM6uNAm+Nw2uYDm8PvPO2kASC3Moh2bBA==",
+      "version": "1.4.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.4.3-r.2.tgz",
+      "integrity": "sha512-2by72HWrmuZFLanVClXme8n2QwMN82bi+b2jVTH2xGhAVMUGSdbsp/kTf2zxhfmsLtcX9gYwSzqMApIdz5GI2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@duckdb/node-bindings": "1.4.3-r.1"
+        "@duckdb/node-bindings": "1.4.3-r.2"
       }
     },
     "node_modules/@duckdb/node-bindings": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.4.3-r.1.tgz",
-      "integrity": "sha512-I7rkYeNYDs9oV9AU076m9msrWb4wdVXapX1y2em8YkGItn4ehyp8q0KEJ2QZy45+PLqmkHt9b/QHlDo8xKnLZQ==",
+      "version": "1.4.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.4.3-r.2.tgz",
+      "integrity": "sha512-yUnOblF+xL41TtPadt1JYAZEIQiYcFr5CKnQCqM+h/KRd1ft/PsX2kex5hQBFGzS/yBKn27c305hjGMgBvIfGQ==",
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
-        "@duckdb/node-bindings-darwin-arm64": "1.4.3-r.1",
-        "@duckdb/node-bindings-darwin-x64": "1.4.3-r.1",
-        "@duckdb/node-bindings-linux-arm64": "1.4.3-r.1",
-        "@duckdb/node-bindings-linux-x64": "1.4.3-r.1",
-        "@duckdb/node-bindings-win32-x64": "1.4.3-r.1"
+        "@duckdb/node-bindings-darwin-arm64": "1.4.3-r.2",
+        "@duckdb/node-bindings-darwin-x64": "1.4.3-r.2",
+        "@duckdb/node-bindings-linux-arm64": "1.4.3-r.2",
+        "@duckdb/node-bindings-linux-x64": "1.4.3-r.2",
+        "@duckdb/node-bindings-win32-x64": "1.4.3-r.2"
       }
     },
     "node_modules/@duckdb/node-bindings-darwin-arm64": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.4.3-r.1.tgz",
-      "integrity": "sha512-2dShpy8HmdLwfRLPI+KZaJXN+wA68gOsuAh//Q1C/X0tQbd97WxHo8u7lZqMhaJMvGaInVAxR+KoFSfG2M5jwA==",
+      "version": "1.4.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.4.3-r.2.tgz",
+      "integrity": "sha512-/hqVgl+jA8GX60ysO556e/vhUxDCD+PNcJFiqTT96Yvry8sqRwL5GOpB94wrUS+2fLZxQ5qTjH0WzqTGMeBHYw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2402,12 +2408,13 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-darwin-x64": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.4.3-r.1.tgz",
-      "integrity": "sha512-a6DUVpDolavw1ojq/IBKoEViGzL1oMIP5xlPrqEW+znyDxp85/UfZzCXnH+BYTKgLWBwCUcqlneMtCh4osZ9lQ==",
+      "version": "1.4.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.4.3-r.2.tgz",
+      "integrity": "sha512-84Ix+4XU+JWyXP5Q/151fwS9piFI++rHLj9Jya2TMsdpBxSqxG7pUKfCRSLpsoxn7ej1AOVtZdcaO4TGTdl4Aw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2415,12 +2422,13 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-arm64": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.4.3-r.1.tgz",
-      "integrity": "sha512-WQ/khu+KCEH34JxDAfa8IDCw0m5NUefpqT4izbH372OAAiY/858xrtcB8FYW0p9Yeb6P8dglHQ058FoLBQ7MhA==",
+      "version": "1.4.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.4.3-r.2.tgz",
+      "integrity": "sha512-e/RfvosNxj97vsnKPm5ealyTeMXKFbJt7rgOHsF3nAqqzWL8WsVqJ3ZsW2fg6NWmJYkp7Mz3md/AR8mQNAuS4Q==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2428,12 +2436,13 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-linux-x64": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.4.3-r.1.tgz",
-      "integrity": "sha512-GWZPi+eAsv2/6TQch+b6AgnPiVnXjhmT7l9gbZMZ17fDSIkKXSbWa9Y3dDJ8amDu/IJpwBMFVovfLHrELbMmlA==",
+      "version": "1.4.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.4.3-r.2.tgz",
+      "integrity": "sha512-YUnt2vJOXmn3y7dvgV2uw9hoKMy1IQIFV1uCX3ZeoIsmrshNwlhbBDyquGgt9HHn/2vz+omCGz0oGwTuifaKHA==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2441,12 +2450,13 @@
       ]
     },
     "node_modules/@duckdb/node-bindings-win32-x64": {
-      "version": "1.4.3-r.1",
-      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.4.3-r.1.tgz",
-      "integrity": "sha512-7II6t8/0opHz6NFosrn5VSv3uMadtOhVRfBK+HzEvxTSkGEpu6DzQ91mPaiehuFctdB2upPza4dP3rCLYDdHeQ==",
+      "version": "1.4.3-r.2",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.4.3-r.2.tgz",
+      "integrity": "sha512-TJoM4nUGuxPVv5G8S6wlgz2ojtOZKTSdud+brGSTKcxVlJF/UZ4tiXIa4gOhTEMmWMYes7Xc95I4YY7qF8DhUg==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4418,6 +4428,93 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@malloydata/db-duckdb/node_modules/@duckdb/node-api": {
+      "version": "1.4.3-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-api/-/node-api-1.4.3-r.1.tgz",
+      "integrity": "sha512-/L6nywAWDnMptERJiO3npCu8XqWYGSo2prw6RvxERtjT9J95cnUP+WM6uNAm+Nw2uYDm8PvPO2kASC3Moh2bBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@duckdb/node-bindings": "1.4.3-r.1"
+      }
+    },
+    "node_modules/@malloydata/db-duckdb/node_modules/@duckdb/node-bindings": {
+      "version": "1.4.3-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings/-/node-bindings-1.4.3-r.1.tgz",
+      "integrity": "sha512-I7rkYeNYDs9oV9AU076m9msrWb4wdVXapX1y2em8YkGItn4ehyp8q0KEJ2QZy45+PLqmkHt9b/QHlDo8xKnLZQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@duckdb/node-bindings-darwin-arm64": "1.4.3-r.1",
+        "@duckdb/node-bindings-darwin-x64": "1.4.3-r.1",
+        "@duckdb/node-bindings-linux-arm64": "1.4.3-r.1",
+        "@duckdb/node-bindings-linux-x64": "1.4.3-r.1",
+        "@duckdb/node-bindings-win32-x64": "1.4.3-r.1"
+      }
+    },
+    "node_modules/@malloydata/db-duckdb/node_modules/@duckdb/node-bindings-darwin-arm64": {
+      "version": "1.4.3-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.4.3-r.1.tgz",
+      "integrity": "sha512-2dShpy8HmdLwfRLPI+KZaJXN+wA68gOsuAh//Q1C/X0tQbd97WxHo8u7lZqMhaJMvGaInVAxR+KoFSfG2M5jwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@malloydata/db-duckdb/node_modules/@duckdb/node-bindings-darwin-x64": {
+      "version": "1.4.3-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.4.3-r.1.tgz",
+      "integrity": "sha512-a6DUVpDolavw1ojq/IBKoEViGzL1oMIP5xlPrqEW+znyDxp85/UfZzCXnH+BYTKgLWBwCUcqlneMtCh4osZ9lQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@malloydata/db-duckdb/node_modules/@duckdb/node-bindings-linux-arm64": {
+      "version": "1.4.3-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.4.3-r.1.tgz",
+      "integrity": "sha512-WQ/khu+KCEH34JxDAfa8IDCw0m5NUefpqT4izbH372OAAiY/858xrtcB8FYW0p9Yeb6P8dglHQ058FoLBQ7MhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@malloydata/db-duckdb/node_modules/@duckdb/node-bindings-linux-x64": {
+      "version": "1.4.3-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.4.3-r.1.tgz",
+      "integrity": "sha512-GWZPi+eAsv2/6TQch+b6AgnPiVnXjhmT7l9gbZMZ17fDSIkKXSbWa9Y3dDJ8amDu/IJpwBMFVovfLHrELbMmlA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@malloydata/db-duckdb/node_modules/@duckdb/node-bindings-win32-x64": {
+      "version": "1.4.3-r.1",
+      "resolved": "https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.4.3-r.1.tgz",
+      "integrity": "sha512-7II6t8/0opHz6NFosrn5VSv3uMadtOhVRfBK+HzEvxTSkGEpu6DzQ91mPaiehuFctdB2upPza4dP3rCLYDdHeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@malloydata/db-mysql": {
       "version": "0.0.334",

--- a/package.json
+++ b/package.json
@@ -765,7 +765,10 @@
   },
   "devDependencies": {
     "@chialab/esbuild-plugin-worker": "^0.18.1",
+    "@duckdb/node-api": "^1.4.3-r.2",
     "@jest/globals": "^26.6.2",
+    "@malloydata/malloy-filter": "0.0.334",
+    "@malloydata/malloy-tag": "0.0.334",
     "@types/jest": "^29.2.1",
     "@types/jsdom": "^16.2.11",
     "@types/lodash": "^4.14.191",

--- a/scripts/malloy-packages.ts
+++ b/scripts/malloy-packages.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env ts-node
 import packageJson from '../package.json';
 
-let malloyPackages = Object.keys(packageJson.dependencies).filter(name =>
-  name.startsWith('@malloy')
-);
+let malloyPackages = Object.keys({
+  ...packageJson.dependencies,
+  ...packageJson.devDependencies,
+}).filter(name => name.startsWith('@malloydata/'));
 
 const nonCorePackages = ['@malloydata/malloy-explorer'];
 // [NODE, SCRIPT-PATH, real arguments ]


### PR DESCRIPTION
Add dev dependencies for transitive malloy dependencies so that running malloy-link works again. Could probably expend the malloy-packages to do this automatically, but this is a quick fix.