### PR TITLE
Fix duckdb connection lookup in web extension

### DIFF
--- a/src/common/connection_manager.ts
+++ b/src/common/connection_manager.ts
@@ -38,7 +38,7 @@ export function isSecretKeyReference(
     typeof value === 'object' &&
     value !== null &&
     'secretKey' in value &&
-    typeof (value as Record<string, unknown>)['secretKey'] === 'string'
+    typeof value['secretKey'] === 'string'
   );
 }
 
@@ -414,12 +414,24 @@ export class CommonConnectionManager {
     };
     const secret = this.secretOverlay();
     if (secret) overlays['secret'] = secret;
+    const connections: Record<string, ConnectionConfigEntry> = {};
+    // Factory-provided defaults (e.g. browser exposes duckdb_wasm as `duckdb`)
+    // come first so that user settings can override them.
+    const factoryDefaults = this.connectionFactory.getDefaultConnections?.();
+    if (factoryDefaults) {
+      for (const [name, type] of Object.entries(factoryDefaults)) {
+        connections[name] = {is: type};
+      }
+    }
+    if (this.settingsConfig) {
+      Object.assign(connections, translateSettingsEntries(this.settingsConfig));
+    }
     const pojo: {
       includeDefaultConnections: boolean;
       connections?: Record<string, ConnectionConfigEntry>;
     } = {includeDefaultConnections: true};
-    if (this.settingsConfig) {
-      pojo.connections = translateSettingsEntries(this.settingsConfig);
+    if (Object.keys(connections).length > 0) {
+      pojo.connections = connections;
     }
     const config = new MalloyConfig(pojo, overlays);
     return {config};
@@ -445,26 +457,23 @@ export class CommonConnectionManager {
   }
 
   /**
-   * Build default connections info from the registry. Used by the
-   * getConnectionTypeInfo handler to populate the sidebar.
+   * Default connections for the sidebar. When the factory declares its own
+   * default list (e.g. the browser advertises `duckdb_wasm` only as
+   * `duckdb`), that list is authoritative. Otherwise: one entry per
+   * registered type plus the `md → duckdb` MotherDuck alias.
    */
-  static getDefaultConnectionTypes(): Record<string, string> {
-    const registeredTypes = getRegisteredConnectionTypes();
-
-    // Browser: only duckdb_wasm is available — alias it as 'duckdb'
-    if (
-      registeredTypes.includes('duckdb_wasm') &&
-      !registeredTypes.includes('duckdb')
-    ) {
-      return {duckdb: 'duckdb_wasm'};
+  getDefaultConnectionTypes(): Record<string, string> {
+    const factoryDefaults = this.connectionFactory.getDefaultConnections?.();
+    if (factoryDefaults) {
+      return {...factoryDefaults};
     }
-
-    // Node: one entry per registered type + md (MotherDuck) alias
     const defaults: Record<string, string> = {};
-    for (const typeName of registeredTypes) {
+    for (const typeName of getRegisteredConnectionTypes()) {
       defaults[typeName] = typeName;
     }
-    defaults['md'] = 'duckdb';
+    if (defaults['duckdb']) {
+      defaults['md'] = 'duckdb';
+    }
     return defaults;
   }
 }

--- a/src/common/connections/types.ts
+++ b/src/common/connections/types.ts
@@ -7,4 +7,20 @@ import {Connection} from '@malloydata/malloy';
 
 export interface ConnectionFactory {
   postProcessConnection?(conn: Connection, workingDir: string): void;
+
+  /**
+   * Default connections (name → registered type) this host wants to expose.
+   * When implemented, this is **authoritative**: the manager uses exactly
+   * this list for the sidebar and pre-seeds the level-3 runtime config with
+   * matching `{is: type}` entries, so `lookupConnection(name)` resolves to
+   * `type`. Used for environments where a registered type should be
+   * presented under a friendlier name — notably the browser, which
+   * registers `duckdb_wasm` but advertises it as `duckdb`.
+   *
+   * When not implemented, the manager falls back to the registry-derived
+   * default list (one entry per registered type plus the `md → duckdb`
+   * alias), and relies on malloy core's `includeDefaultConnections: true`
+   * to fabricate matching connections at runtime.
+   */
+  getDefaultConnections?(): Record<string, string>;
 }

--- a/src/server/connections/browser/connection_factory.ts
+++ b/src/server/connections/browser/connection_factory.ts
@@ -10,10 +10,21 @@ import {ConnectionFactory} from '../../../common/connections/types';
 import {GenericConnection} from '../../../common/types/worker_message_types';
 import {errorMessage} from '../../../common/errors';
 
+// Browser ships only DuckDB-WASM; expose it under the friendlier `duckdb`
+// name that malloy samples write, and don't advertise `md` (MotherDuck
+// isn't supported on the WASM build).
+const DEFAULT_CONNECTIONS: Readonly<Record<string, string>> = Object.freeze({
+  duckdb: 'duckdb_wasm',
+});
+
 export class WebConnectionFactory implements ConnectionFactory {
   private registeredConnections = new WeakSet<Connection>();
 
   constructor(private client: GenericConnection) {}
+
+  getDefaultConnections(): Record<string, string> {
+    return {...DEFAULT_CONNECTIONS};
+  }
 
   postProcessConnection(conn: Connection, workingDir: string): void {
     if (this.registeredConnections.has(conn)) return;

--- a/src/worker/message_handler.ts
+++ b/src/worker/message_handler.ts
@@ -109,7 +109,9 @@ export class MessageHandler implements WorkerMessageHandler {
         }));
       }
       const defaultConnections =
-        CommonConnectionManager.getDefaultConnectionTypes();
+        connectionManager instanceof CommonConnectionManager
+          ? connectionManager.getDefaultConnectionTypes()
+          : {};
       return {
         registeredTypes: types,
         typeDisplayNames,

--- a/test/common/connection_registration.spec.ts
+++ b/test/common/connection_registration.spec.ts
@@ -14,50 +14,74 @@ jest.mock('@malloydata/malloy', () => {
 });
 
 import {CommonConnectionManager} from '../../src/common/connection_manager';
+import {ConnectionFactory} from '../../src/common/connections/types';
+
+const nodeFactory: ConnectionFactory = {};
+const browserFactory: ConnectionFactory = {
+  getDefaultConnections: () => ({duckdb: 'duckdb_wasm'}),
+};
 
 describe('getDefaultConnectionTypes', () => {
   afterEach(() => {
     mockRegisteredTypes = [];
   });
 
-  it('browser: aliases duckdb to duckdb_wasm when only wasm is registered', () => {
+  it('browser: factory list is authoritative — only `duckdb` shown, no md', () => {
     mockRegisteredTypes = ['duckdb_wasm'];
 
-    const defaults = CommonConnectionManager.getDefaultConnectionTypes();
+    const defaults = new CommonConnectionManager(
+      browserFactory
+    ).getDefaultConnectionTypes();
 
-    expect(defaults).toEqual({
-      duckdb: 'duckdb_wasm',
-    });
-    // No md alias in browser
+    expect(defaults).toEqual({duckdb: 'duckdb_wasm'});
+    // The bare `duckdb_wasm` type isn't surfaced — the factory speaks for it.
+    expect(defaults['duckdb_wasm']).toBeUndefined();
+    // MotherDuck isn't supported on WASM, so no md alias.
     expect(defaults['md']).toBeUndefined();
   });
 
-  it('node: creates one entry per type plus md alias', () => {
+  it('node: one entry per registered type plus md alias', () => {
     mockRegisteredTypes = ['duckdb', 'postgres', 'bigquery'];
 
-    const defaults = CommonConnectionManager.getDefaultConnectionTypes();
+    const defaults = new CommonConnectionManager(
+      nodeFactory
+    ).getDefaultConnectionTypes();
 
-    expect(defaults['duckdb']).toEqual('duckdb');
-    expect(defaults['postgres']).toEqual('postgres');
-    expect(defaults['bigquery']).toEqual('bigquery');
-    expect(defaults['md']).toEqual('duckdb');
+    expect(defaults['duckdb']).toBe('duckdb');
+    expect(defaults['postgres']).toBe('postgres');
+    expect(defaults['bigquery']).toBe('bigquery');
+    expect(defaults['md']).toBe('duckdb');
   });
 
-  it('node: includes md alias even with only duckdb registered', () => {
+  it('node: includes md alias when only duckdb is registered', () => {
     mockRegisteredTypes = ['duckdb'];
 
-    const defaults = CommonConnectionManager.getDefaultConnectionTypes();
+    const defaults = new CommonConnectionManager(
+      nodeFactory
+    ).getDefaultConnectionTypes();
 
-    expect(defaults['duckdb']).toEqual('duckdb');
-    expect(defaults['md']).toEqual('duckdb');
+    expect(defaults['duckdb']).toBe('duckdb');
+    expect(defaults['md']).toBe('duckdb');
   });
 
-  it('returns empty when nothing is registered', () => {
+  it('node: no md alias when duckdb is not registered', () => {
+    mockRegisteredTypes = ['postgres'];
+
+    const defaults = new CommonConnectionManager(
+      nodeFactory
+    ).getDefaultConnectionTypes();
+
+    expect(defaults).toEqual({postgres: 'postgres'});
+    expect(defaults['md']).toBeUndefined();
+  });
+
+  it('returns empty when nothing is registered and factory is silent', () => {
     mockRegisteredTypes = [];
 
-    const defaults = CommonConnectionManager.getDefaultConnectionTypes();
+    const defaults = new CommonConnectionManager(
+      nodeFactory
+    ).getDefaultConnectionTypes();
 
-    // No wasm, no duckdb — falls through to node path with empty loop
-    expect(defaults).toEqual({md: 'duckdb'});
+    expect(defaults).toEqual({});
   });
 });

--- a/test/common/malloy_config.spec.ts
+++ b/test/common/malloy_config.spec.ts
@@ -564,6 +564,76 @@ describe('CommonConnectionManager', () => {
     });
   });
 
+  describe('factory default connections', () => {
+    // Stand-in for the browser's `duckdb_wasm`: a registered type the
+    // factory exposes under a friendlier name (`aliasdb`), mirroring how
+    // the web factory presents `duckdb_wasm` as `duckdb`. The factory
+    // function tags each instance with `_type` so we can assert which
+    // backend the resolver landed on.
+    beforeAll(() => {
+      registerConnectionType('aliastarget', {
+        displayName: 'Alias Target',
+        factory: async config =>
+          ({name: config.name, _type: 'aliastarget'}) as unknown as Connection,
+        properties: [],
+      });
+      registerConnectionType('overridetarget', {
+        displayName: 'Override Target',
+        factory: async config =>
+          ({
+            name: config.name,
+            _type: 'overridetarget',
+          }) as unknown as Connection,
+        properties: [],
+      });
+    });
+
+    const factory: ConnectionFactory = {
+      getDefaultConnections: () => ({aliasdb: 'aliastarget'}),
+    };
+
+    it('runtime resolves connection lookups under the factory-declared name', async () => {
+      const manager = new CommonConnectionManager(factory);
+      manager.setURLReader(makeMockURLReader());
+      manager.setWorkspaceRoots(['file:///project/']);
+
+      const lookup = await manager.getConnectionLookup(
+        new URL('file:///project/test.malloy')
+      );
+      const conn = (await lookup.lookupConnection('aliasdb')) as Connection & {
+        _type: string;
+      };
+      expect(conn._type).toBe('aliastarget');
+      expect(conn.name).toBe('aliasdb');
+    });
+
+    it('user settings override the factory default', async () => {
+      const manager = new CommonConnectionManager(factory);
+      manager.setURLReader(makeMockURLReader());
+      manager.setWorkspaceRoots(['file:///project/']);
+      manager.setConnectionsConfig({
+        aliasdb: {is: 'overridetarget'},
+      });
+
+      const lookup = await manager.getConnectionLookup(
+        new URL('file:///project/test.malloy')
+      );
+      const conn = (await lookup.lookupConnection('aliasdb')) as Connection & {
+        _type: string;
+      };
+      expect(conn._type).toBe('overridetarget');
+    });
+
+    it('sidebar default list is exactly what the factory declared', () => {
+      const defaults = new CommonConnectionManager(
+        factory
+      ).getDefaultConnectionTypes();
+      // Factory list is authoritative — registry-derived entries are not
+      // mixed in, so neither `aliastarget` nor `md` show up.
+      expect(defaults).toEqual({aliasdb: 'aliastarget'});
+    });
+  });
+
   describe('DuckDB working directory', () => {
     it('discoverConfig ceiling is workspace root, not file directory', async () => {
       mockDiscoverResult = null;
@@ -752,9 +822,8 @@ describe('isSecretKeyReference', () => {
 
 describe('getDefaultConnectionTypes', () => {
   it('returns a name→type mapping', () => {
-    const defaults = CommonConnectionManager.getDefaultConnectionTypes();
+    const manager = new CommonConnectionManager({});
+    const defaults = manager.getDefaultConnectionTypes();
     expect(typeof defaults).toBe('object');
-    // md alias should map to duckdb
-    expect(defaults['md']).toBe('duckdb');
   });
 });


### PR DESCRIPTION
## Summary

- Web extension registers `duckdb_wasm` as the only backend, but malloy samples write `duckdb.table(...)`. Defaults fabricated by malloy core use type names, so the runtime had a `duckdb_wasm` connection but no `duckdb` — `lookupConnection('duckdb')` failed with "No connection named 'duckdb' found in config". The prior registry-inference fallback only fixed the sidebar UI, not the runtime config.
- Replaced the inference with an explicit `ConnectionFactory.getDefaultConnections` hook. The web factory declares `{duckdb: 'duckdb_wasm'}`; the node factory opts out and falls back to registry-derived defaults plus the `md` alias. The factory list also seeds level-3 runtime connections so the resolver answers to the friendlier name.
- User settings still override factory defaults.
- Drive-by: dropped a redundant cast in `isSecretKeyReference`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json`
- [x] `npm run lint`
- [x] `npm run build` (node + browser)
- [x] `npx jest --no-cache` — 130 pass, including new tests:
  - runtime resolves `lookupConnection` under the factory-declared name
  - user settings override the factory default
  - sidebar default list is exactly the factory list (no registry leakage, no `md` in browser)
  - browser/node registry-inference cases (rewritten against the new factory contract)
- [x] Manually reproduced the bug in web vscode pre-release on `~/malloy-samples/names/names.malloy`, confirmed the fix resolves it.