### PR TITLE
Fix notebook cells losing project connections

### DIFF
--- a/src/common/connection_manager.ts
+++ b/src/common/connection_manager.ts
@@ -92,6 +92,37 @@ function isAncestor(ancestor: URL, descendant: URL): boolean {
   return d === a || d.startsWith(a.endsWith('/') ? a : a + '/');
 }
 
+/**
+ * Normalize a `vscode-notebook-cell:` URI to the underlying notebook file's
+ * URI for purposes of config resolution and workspace lookup.
+ *
+ * Cell URIs are not real file URIs. When `discoverConfig` walks up looking
+ * for `malloy-config.json`, it URL-joins the filename onto each parent
+ * directory — and the join preserves the `vscode-notebook-cell:` scheme,
+ * producing URLs like `vscode-notebook-cell:/.../malloy-config.json` that
+ * nothing knows how to serve. The notebook is then treated as if no
+ * project config existed, which silently breaks every connection-using
+ * cell. Tests live in `test/common/connection_manager.spec.ts`.
+ *
+ * The notebook file shares the cell's path; we borrow the scheme from a
+ * matching workspace root (covers desktop `file:` and web `vscode-vfs:`)
+ * and fall back to `file:` outside any workspace.
+ */
+export function notebookCellToFileURL(
+  fileURL: URL,
+  workspaceRoots: URL[]
+): URL {
+  if (fileURL.protocol !== 'vscode-notebook-cell:') {
+    return fileURL;
+  }
+  const root = workspaceRoots.find(r => {
+    const rootPath = r.pathname.endsWith('/') ? r.pathname : r.pathname + '/';
+    return fileURL.pathname.startsWith(rootPath);
+  });
+  const scheme = root?.protocol ?? 'file:';
+  return new URL(`${scheme}//${fileURL.host}${fileURL.pathname}`);
+}
+
 export class CommonConnectionManager {
   currentRowLimit = 50;
   private workspaceRoots: URL[] = [];
@@ -221,6 +252,7 @@ export class CommonConnectionManager {
   }
 
   private async resolveConfigForFile(fileURL: URL): Promise<CachedConfig> {
+    fileURL = notebookCellToFileURL(fileURL, this.workspaceRoots);
     const workspaceFolder = this.workspaceFolderFor(fileURL);
     const fileDir = new URL('.', fileURL).toString();
 

--- a/src/common/connections/CONTEXT.md
+++ b/src/common/connections/CONTEXT.md
@@ -26,6 +26,8 @@ Key pieces the extension leans on:
 
 `CommonConnectionManager.resolveConfigForFile(fileURL)` picks one of three levels for each file. **First match wins — no merging between levels.** The presence of a config file is the trust boundary: with a config file, settings connections do not leak in.
 
+> **Cell URIs are normalized first.** `resolveConfigForFile` runs `notebookCellToFileURL` (in `connection_manager.ts`) on the input URL before any of the levels below. Cell URIs (`vscode-notebook-cell:`) are not real file URIs — `discoverConfig` URL-joins `malloy-config.json` onto each parent directory, and the join preserves the cell scheme, producing URLs nothing can serve. Skip this normalization and every notebook falls through to the defaults-only fallback (level 3 minus settings) — connections from `malloy-config.json` quietly disappear, and the symptom shows up as the notebook chain failing ("cell N can't see definitions from cell K"). Regression test: `test/common/connection_manager.spec.ts`.
+
 1. **Discovered (project) config.** `discoverConfig(fileURL, workspaceFolder, urlReader)`. The workspace folder is the ceiling.
 2. **Global config.** `<globalConfigDirectory>/malloy-config.json`, if the setting is set and no project config was found. The `config` overlay still gets `rootDirectory: workspaceFolder` — DuckDB's anchor is always the workspace.
 3. **Settings + defaults.** Settings-based connections (`connectionMap`) are translated into the config POJO alongside `includeDefaultConnections: true`, so the registry fabricates one entry per backend type not already declared. Secret references in settings entries resolve through a scoped `secret` overlay (see below).

--- a/src/extension/notebook/CONTEXT.md
+++ b/src/extension/notebook/CONTEXT.md
@@ -5,9 +5,60 @@ Support for `.malloynb` files — interactive notebooks combining Malloy code, S
 ## Key Concepts
 
 - Notebooks use a custom JSON format (not Jupyter `.ipynb`)
-- Each cell can be Malloy code or markdown
-- Cells are **chained**: each cell's model extends the previous cell's compiled model
+- Each cell is Malloy code, Malloy-SQL, or markdown
+- Cells are **chained**: a cell sees every prior code cell's definitions, as if they were one document
 - Per-cell `malloy:` metadata can override connection settings
+
+## How Cell Chaining Works
+
+Cell N never compiles in isolation. Every time the language server compiles cell N (for diagnostics, completions, hover, code actions, lenses), it rebuilds the chain from scratch. There is no per-notebook cached chained model.
+
+### The chain
+
+`TranslateCache.createModelMaterializer` in `src/server/translate_cache.ts` is the entry point. When it sees a `vscode-notebook-cell:` URI it:
+
+1. **Asks for the cell list.** `getCellData(cellN.uri)` → RPC `malloy/fetchCellData` → the extension's `fetchCellData` in `src/extension/utils/files.ts`. That iterates `notebook.getCells()` in document order and returns every code cell **up to and including** cell N.
+2. **Walks the list.** First code cell: `runtime.loadModel(cell0.uri, …)`. Every subsequent cell: `modelMaterializer.extendModel(cellK.uri, …)`. The Malloy compiler dereferences each URL, fetches that cell's text, and layers its definitions onto the materializer.
+3. **Returns the chained model.** `noThrowOnError: true` is set, so a broken earlier cell does **not** throw — its problems show up in the returned model's `problems` array. A silent compile failure in cell K shows up as cell N "not seeing" cell K's definitions.
+
+`importBaseURL` is the notebook's own URI (or, for `untitled:` notebooks, the workspace folder), so relative `import "..."` resolves against the notebook directory, not against the cell URI.
+
+### How cell text gets resolved
+
+Steps 2 and 3 above need to read the text of every cell in the chain. That goes through `urlReader.readURL` → `TranslateCache.getDocumentText` (`src/server/translate_cache.ts`). It tries two paths in order:
+
+1. **LSP cache (fast).** `documents.get(uri.toString())`. The LSP only knows about cells that were sent to it via didOpen. The LSP client registers notebook cells in its `documentSelector` in `src/extension/node/extension_node.ts` and `src/extension/browser/extension_browser.ts`:
+
+   ```ts
+   {language: 'malloy',     notebook: {notebookType: 'malloy-notebook', scheme: '*'}},
+   {language: 'malloy-sql', notebook: {notebookType: 'malloy-notebook', scheme: '*'}},
+   ```
+
+   Remove either entry and cells of that language stop arriving at the LSP — every read for them falls through to path 2, and any breakage of path 2 then breaks the chain.
+
+2. **RPC fallback.** `malloy/fetchFile` → extension `fetchFile` in `src/extension/utils/files.ts`. The `notebookCellDocument` helper resolves the cell URL to the live cell document (`notebook.uri.path === uri.path`, then `cell.document.uri.fragment === uri.fragment`) and returns its text. **Do not** let `vscode-notebook-cell:` URIs fall through to `workspace.fs.readFile`; that reads the whole notebook container, not the cell, and silently breaks the chain.
+
+The same `fetchFile` is also reached from the worker (cell execution path) via the `malloy/fetch` RPC, so it is the single chokepoint for any cross-cell read that is not in the LSP cache.
+
+### Cell URI shape
+
+`vscode-notebook-cell:/<path-to-notebook>#<fragment>`. The path matches the underlying notebook file's path; the fragment uniquely identifies the cell within the notebook. `fetchCellData` and `notebookCellDocument` both depend on this — they look up the notebook by `path` and the cell by `fragment`.
+
+### Contracts to preserve
+
+These five invariants together produce "cells feel like one document". Break any one and cross-cell references silently fail:
+
+| # | Contract | Lives in | If broken |
+|---|---|---|---|
+| 1 | LSP `documentSelector` includes notebook cell entries for every cell language | `extension_node.ts`, `extension_browser.ts` | Cells aren't synced to LSP; every read goes via RPC |
+| 2 | `fetchCellData` returns code cells in document order, up through the requested cell | `utils/files.ts` | Wrong/short chain — earlier cells invisible |
+| 3 | `fetchFile` resolves `vscode-notebook-cell:` URIs to live cell text, never to the notebook container | `utils/files.ts` (`notebookCellDocument`) | For a cell URI not already in `vscode.workspace.textDocuments`, fetchFile falls through to `workspace.fs.readFile` and returns the whole notebook JSON in place of cell text — chain breaks silently. Most likely to bite on the worker / Run-cell path, which has no LSP `documents` cache to mask the gap. |
+| 4 | `createModelMaterializer` walks every code cell up to the target with `loadModel` then `extendModel` | `server/translate_cache.ts` | Cell N can't see definitions from cells 0..N-1 |
+| 5 | Cell URIs are normalized to the notebook file URI before connection-config resolution | `common/connection_manager.ts` (`notebookCellToFileURL`) | Config discovery walks up using `vscode-notebook-cell:` URLs that nothing can serve, so every cell falls through to the defaults-only fallback — connections defined in `malloy-config.json` vanish, sources fail to compile, the chain shows a confusing "undefined object" error in cell N |
+
+Contract #5 is non-obvious: connection resolution and cell chaining look unrelated, but a cell URI fed to `discoverConfig` walks up using `vscode-notebook-cell:` URLs that nothing can serve, so config silently falls back to defaults. The chain itself is fine; every cell just can't reach its database. See `src/common/connections/CONTEXT.md` ("Notebook Cell URIs").
+
+Regression tests: `test/extension/files.spec.ts` (#3), `test/common/connection_manager.spec.ts` (#5).
 
 ## Files
 
@@ -33,7 +84,3 @@ Custom notebook output renderers:
 - `malloy_entry.tsx` — renders query results in notebook cells; posts `malloy.renderLogs` messages back to the extension host with render validation logs
 - `MalloyRenderer.tsx` — result display component
 - `schema_entry.tsx` — renders schema output in notebook cells
-
-## Cell URI Scheme
-
-Notebook cells use `vscode-notebook-cell:` URIs (e.g., `file.malloynb#W5s...`). The language server's `TranslateCache` handles these specially, chaining models from previous cells.

--- a/src/extension/utils/files.ts
+++ b/src/extension/utils/files.ts
@@ -51,6 +51,32 @@ const fixNotebookUri = (uri: vscode.Uri) => {
 };
 
 /**
+ * Resolves a `vscode-notebook-cell:` Uri to the live cell's TextDocument.
+ *
+ * The Malloy compiler walks cell URLs across `loadModel`/`extendModel` to
+ * chain a notebook's cells into one model. `fetchFile` MUST resolve those
+ * cell URLs back to per-cell text — falling through to `workspace.fs.readFile`
+ * reads the whole notebook container and breaks any definition that crosses
+ * cell boundaries. See `src/extension/notebook/CONTEXT.md` ("Cell URI Scheme")
+ * and the regression test in `test/extension/files.spec.ts`.
+ *
+ * Distinct from `fixNotebookUri`, which rewrites a cell Uri to a file Uri for
+ * binary/container reads — do not consolidate.
+ */
+const notebookCellDocument = (uri: vscode.Uri) => {
+  if (uri.scheme !== 'vscode-notebook-cell') {
+    return undefined;
+  }
+
+  const notebook = vscode.workspace.notebookDocuments.find(
+    notebook => notebook.uri.path === uri.path
+  );
+  return notebook
+    ?.getCells()
+    .find(cell => cell.document.uri.fragment === uri.fragment)?.document;
+};
+
+/**
  * Fetches the text contents of a Uri for the Malloy compiler. For most Uri
  * types this means either from the open file cache, or from VS Code's
  * file system.
@@ -69,6 +95,11 @@ export async function fetchFile(uriString: string): Promise<string> {
     } else {
       throw new Error(`Unable to fetch ${uriString}: ${response.statusText}`);
     }
+  }
+
+  const cellDocument = notebookCellDocument(uri);
+  if (cellDocument) {
+    return cellDocument.getText();
   }
 
   const openDocument = openFiles.find(

--- a/src/server/CONTEXT.md
+++ b/src/server/CONTEXT.md
@@ -28,7 +28,7 @@ Document lifecycle:
 - `translateWithCache(uri)` — compiles Malloy to validated model, caches by URI
 - Creates ephemeral `Runtime` per operation with connection lookups
 - Tracks import dependency graph for cascading invalidation
-- Notebook support: chains cell models (`vscode-notebook-cell:` URIs)
+- Notebook support: `createModelMaterializer` chains cell models (`loadModel` then `extendModel` over every prior code cell). Full mechanism documented in `src/extension/notebook/CONTEXT.md` ("How Cell Chaining Works").
 - `translateWithTruncatedCache()` — partial compilation for fast schema completions
 
 ### `parse_cache.ts` — Syntax Parse Cache

--- a/src/server/translate_cache.ts
+++ b/src/server/translate_cache.ts
@@ -178,6 +178,10 @@ export class TranslateCache {
       }
       const cellData = await this.getCellData(new URL(uri));
       const importBaseURL = new URL(cellData.baseUri);
+      const malloyCells = cellData.cells.filter(c => c.languageId === 'malloy');
+      this.connection.console.info(
+        `createModelMaterializer ${prettyUri} chaining ${malloyCells.length} malloy cell(s)`
+      );
       for (const cell of cellData.cells) {
         if (cell.languageId === 'malloy') {
           const url = new URL(cell.uri);
@@ -343,6 +347,17 @@ export class TranslateCache {
         refreshSchemaCache
       );
       const model = await modelMaterializer?.getModel();
+      if (model?.problems?.length) {
+        this.connection.console.info(
+          `translateWithCache ${prettyUri} model has ${
+            model.problems.length
+          } problem(s); first problem at ${
+            model.problems[0].at?.url
+              ? prettyLogUri(model.problems[0].at.url)
+              : '(no url)'
+          }: ${model.problems[0].message}`
+        );
+      }
       this.connection.console.info(
         `translateWithCache ${prettyUri} end in ${prettyTime(
           performance.now() - t0

--- a/test/common/connection_manager.integration.spec.ts
+++ b/test/common/connection_manager.integration.spec.ts
@@ -5,7 +5,7 @@
 
 import {CommonConnectionManager} from '../../src/common/connection_manager';
 import {ConnectionFactory} from '../../src/common/connections/types';
-import {MalloyConfig, URLReader} from '@malloydata/malloy';
+import {discoverConfig, MalloyConfig, URLReader} from '@malloydata/malloy';
 
 // Mock discoverConfig so we can control what it returns
 let mockDiscoverResult: MalloyConfig | null = null;
@@ -68,5 +68,26 @@ describe('CommonConnectionManager integration', () => {
     const config1 = await manager.getConfigForFile(url1);
     const config2 = await manager.getConfigForFile(url2);
     expect(config1).toBe(config2);
+  });
+
+  // Wiring guard: the unit test on `notebookCellToFileURL` proves the helper
+  // works in isolation, but only this test proves it's actually called from
+  // `resolveConfigForFile`. Without it, removing the normalization line would
+  // pass every other test and silently re-introduce the cell-URI config bug.
+  it('normalizes vscode-notebook-cell URIs before discoverConfig walks', async () => {
+    const factory: ConnectionFactory = {};
+    const manager = new CommonConnectionManager(factory);
+    manager.setURLReader(makeMockURLReader());
+    manager.setWorkspaceRoots(['file:///project/']);
+
+    await manager.getConfigForFile(
+      new URL('vscode-notebook-cell:/project/notebook.malloynb#W5sZmlsZQ%3D%3D')
+    );
+
+    expect(discoverConfig).toHaveBeenCalled();
+    const [startURL] = jest.mocked(discoverConfig).mock.calls[0];
+    expect(startURL.protocol).toBe('file:');
+    expect(startURL.hash).toBe('');
+    expect(startURL.pathname).toBe('/project/notebook.malloynb');
   });
 });

--- a/test/common/connection_manager.spec.ts
+++ b/test/common/connection_manager.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Contributors to the Malloy project
+ * SPDX-License-Identifier: MIT
+ */
+
+import {notebookCellToFileURL} from '../../src/common/connection_manager';
+
+// Regression test for the notebook-cell config-discovery bug. Before this
+// helper existed, getConfigForFile was called with the cell URI; discoverConfig
+// walked up using `vscode-notebook-cell:` URLs that nothing can serve, so every
+// notebook fell through to the defaults-only fallback and silently lost every
+// connection defined in the workspace's `malloy-config.json`. The user-visible
+// symptom was "cell N can't see definitions from cells before it" — really it
+// was "no cell can talk to its database, so any source backed by a configured
+// connection failed to compile, leaving its symbols undefined for the chain."
+// Notebook chaining and connection discovery look unrelated; they're not.
+// See `src/extension/notebook/CONTEXT.md` ("How Cell Chaining Works", contract #5).
+describe('notebookCellToFileURL', () => {
+  const desktopRoot = new URL('file:///Users/mtoy/malloy-imdb/');
+
+  it('converts a vscode-notebook-cell URI to a file URI under a desktop workspace', () => {
+    const cell = new URL(
+      'vscode-notebook-cell:/Users/mtoy/malloy-imdb/imdb.malloynb#W5sZmlsZQ%3D%3D'
+    );
+    const result = notebookCellToFileURL(cell, [desktopRoot]);
+    expect(result.toString()).toBe(
+      'file:///Users/mtoy/malloy-imdb/imdb.malloynb'
+    );
+    expect(result.hash).toBe('');
+  });
+
+  it('borrows the scheme from a matching vscode-vfs workspace root', () => {
+    const vfsRoot = new URL('vscode-vfs://github/malloydata/malloy/');
+    const cell = new URL(
+      'vscode-notebook-cell://github/malloydata/malloy/notebook.malloynb#W5s'
+    );
+    const result = notebookCellToFileURL(cell, [vfsRoot]);
+    expect(result.toString()).toBe(
+      'vscode-vfs://github/malloydata/malloy/notebook.malloynb'
+    );
+  });
+
+  it('falls back to file: scheme when no workspace root matches', () => {
+    const cell = new URL('vscode-notebook-cell:/tmp/loose.malloynb#frag');
+    const result = notebookCellToFileURL(cell, [desktopRoot]);
+    expect(result.toString()).toBe('file:///tmp/loose.malloynb');
+  });
+
+  it('leaves non-cell URIs unchanged', () => {
+    const fileURL = new URL('file:///Users/mtoy/malloy-imdb/imdb.malloy');
+    expect(notebookCellToFileURL(fileURL, [desktopRoot])).toBe(fileURL);
+
+    const untitled = new URL('untitled:/Untitled-1');
+    expect(notebookCellToFileURL(untitled, [desktopRoot])).toBe(untitled);
+  });
+
+  it('handles workspace roots with or without trailing slashes', () => {
+    const noSlashRoot = new URL('file:///Users/mtoy/malloy-imdb');
+    const cell = new URL(
+      'vscode-notebook-cell:/Users/mtoy/malloy-imdb/imdb.malloynb#frag'
+    );
+    const result = notebookCellToFileURL(cell, [noSlashRoot]);
+    expect(result.toString()).toBe(
+      'file:///Users/mtoy/malloy-imdb/imdb.malloynb'
+    );
+  });
+});

--- a/test/extension/files.spec.ts
+++ b/test/extension/files.spec.ts
@@ -1,0 +1,107 @@
+const mockReadFile = jest.fn();
+let mockTextDocuments: unknown[] = [];
+let mockNotebookDocuments: unknown[] = [];
+
+type MockUri = {
+  scheme: string;
+  authority: string;
+  path: string;
+  query: string;
+  fragment: string;
+  toString: () => string;
+};
+
+const mockUri = (uriString: string): MockUri => {
+  const parsed = new URL(uriString);
+  return {
+    scheme: parsed.protocol.replace(/:$/, ''),
+    authority: parsed.host,
+    path: parsed.pathname,
+    query: parsed.search.replace(/^\?/, ''),
+    fragment: parsed.hash.replace(/^#/, ''),
+    toString: () => uriString,
+  };
+};
+
+jest.mock(
+  'vscode',
+  () => ({
+    Uri: {
+      parse: jest.fn((uriString: string) => mockUri(uriString)),
+      from: jest.fn(
+        ({
+          scheme,
+          authority = '',
+          path,
+          query = '',
+        }: {
+          scheme: string;
+          authority?: string;
+          path: string;
+          query?: string;
+        }) => {
+          const queryString = query ? `?${query}` : '';
+          return mockUri(`${scheme}://${authority}${path}${queryString}`);
+        }
+      ),
+    },
+    workspace: {
+      get textDocuments() {
+        return mockTextDocuments;
+      },
+      get notebookDocuments() {
+        return mockNotebookDocuments;
+      },
+      fs: {
+        readFile: mockReadFile,
+      },
+      workspaceFolders: [],
+    },
+  }),
+  {virtual: true}
+);
+
+import {fetchFile} from '../../src/extension/utils/files';
+
+describe('extension file utilities', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTextDocuments = [];
+    mockNotebookDocuments = [];
+  });
+
+  // Regression test for the loadModel/extendModel cross-cell bug: when the
+  // Malloy compiler follows a cell URL, fetchFile MUST return the live cell
+  // text, not fall through to workspace.fs.readFile (which reads the whole
+  // notebook container). See src/extension/notebook/CONTEXT.md.
+  it('reads notebook cell text from the open notebook document', async () => {
+    const cellUri = 'vscode-notebook-cell:///workspace/imdb.malloynb#cell-1';
+    const cellText = 'source: movies is duckdb.sql("""select 1 as id""")\n';
+    const cellDocument = {
+      uri: mockUri(cellUri),
+      getText: jest.fn(() => cellText),
+    };
+    mockNotebookDocuments = [
+      {
+        uri: mockUri('file:///workspace/imdb.malloynb'),
+        getCells: jest.fn(() => [{document: cellDocument}]),
+      },
+    ];
+
+    await expect(fetchFile(cellUri)).resolves.toBe(cellText);
+    expect(cellDocument.getText).toHaveBeenCalledTimes(1);
+    expect(mockReadFile).not.toHaveBeenCalled();
+  });
+
+  // Guards the inverse: non-cell URIs must still reach the filesystem. If a
+  // future change "simplifies" fetchFile by always running the cell lookup,
+  // regular file reads would silently break.
+  it('falls through to the filesystem for non-notebook-cell URIs', async () => {
+    const fileUri = 'file:///workspace/regular.malloy';
+    const fileText = 'source: orders is duckdb.sql("""select 1 as id""")\n';
+    mockReadFile.mockResolvedValueOnce(new TextEncoder().encode(fileText));
+
+    await expect(fetchFile(fileUri)).resolves.toBe(fileText);
+    expect(mockReadFile).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- **The fix.** Cell URIs (`vscode-notebook-cell:`) reached `discoverConfig`, which walked up directories by URL-joining `malloy-config.json` onto each parent — and the join preserved the cell scheme, producing URLs nothing could serve. Every notebook silently fell through to the defaults-only fallback; connections from `malloy-config.json` disappeared, sources backed by them failed to compile, and later cells reported "Reference to undefined object" for symbols their imports should have provided. New `notebookCellToFileURL` helper in `src/common/connection_manager.ts` normalizes cell URIs to the underlying notebook file URI (path preserved, fragment dropped, scheme borrowed from a matching workspace root) at the top of `resolveConfigForFile`, before any resolution machinery runs.
- **Defensive fetchFile.** Adds a `notebookCellDocument` lookup so `fetchFile` resolves `vscode-notebook-cell:` URIs to the live cell document via `vscode.workspace.notebookDocuments` instead of falling through to `workspace.fs.readFile` (which would return the whole `.malloynb` JSON for cell URIs not already in `vscode.workspace.textDocuments`). Most likely to bite on the worker / Run-cell path, which has no LSP `documents` cache to mask the gap.
- **Documentation.** `src/extension/notebook/CONTEXT.md` now has a full "How Cell Chaining Works" section explaining the `loadModel`/`extendModel` walk, the two cell-text resolution paths, the URI shape, and a five-row contracts table covering the invariants future LLMs need to preserve. Cross-referenced from `src/server/CONTEXT.md` and `src/common/connections/CONTEXT.md`.
- **Tests.** Unit test on the new helper (`test/common/connection_manager.spec.ts`), wiring test that asserts `discoverConfig` receives a normalized URL (`test/common/connection_manager.integration.spec.ts`), and a regression test for the defensive `fetchFile` path (`test/extension/files.spec.ts`). 145/145 passing.

## Test plan
- [x] Open a notebook in a workspace whose `malloy-config.json` defines a non-default connection (e.g. `imdb` → DuckDB); confirm cells using that connection compile across the chain without "No connection named ... found in config".
- [x] Define a source in cell 1, reference it in cell 2; cell 2 compiles cleanly with no "Reference to undefined object" for the cell-1 symbol.
- [x] Run a cell (worker path) end-to-end and verify the result is correct.
- [x] `npx jest --no-cache` — 145 passing.
- [ ] `npx tsc --noEmit -p tsconfig.json` — clean.
- [x] `npm run lint` — clean.