### PR TITLE
Re-diagnose sibling notebook cells when one cell changes

### DIFF
--- a/src/server/init.ts
+++ b/src/server/init.ts
@@ -193,6 +193,38 @@ export const initServer = (
 
   documents.onDidChangeContent(change => {
     debouncedDiagnoseDocument(change.document);
+
+    // Re-diagnose sibling cells of the same notebook. The notebook-aggregated
+    // diagnostics published to the .malloynb file URI are built from whatever
+    // cell URIs appear in the current diagnose call's map; without this
+    // fan-out, an error in cell B that became valid because the user edited
+    // cell A stays in the Problems pane until cell B is itself edited.
+    // Translate cache's `dependentsOf` is supposed to catch this, but its
+    // hash-comparison heuristic for "later cell in the same notebook" is
+    // unreliable because cell URI fragments aren't lexicographically ordered
+    // by notebook position. Brute-forcing all siblings keeps it simple.
+    // Cycle-safe: this fan-out only fires from didChangeContent; the
+    // sibling re-diagnose calls don't re-enter this handler.
+    if (change.document.uri.startsWith('vscode-notebook-cell:')) {
+      let url: URL;
+      try {
+        url = new URL(change.document.uri);
+      } catch {
+        return;
+      }
+      for (const otherDoc of documents.all()) {
+        if (otherDoc.uri === change.document.uri) continue;
+        if (!otherDoc.uri.startsWith('vscode-notebook-cell:')) continue;
+        let otherUrl: URL;
+        try {
+          otherUrl = new URL(otherDoc.uri);
+        } catch {
+          continue;
+        }
+        if (otherUrl.pathname !== url.pathname) continue;
+        debouncedDiagnoseDocument(otherDoc);
+      }
+    }
   });
 
   function ejectIfUnused(uri: string) {


### PR DESCRIPTION
## Summary

When a user edits a notebook cell, the language server now re-diagnoses every other cell of the same notebook, not just the one that changed.

**The bug:** notebook-aggregated diagnostics are published to the `.malloynb` file URI via `aggregateNotebookDiagnostics`. That aggregator builds the published list from whichever cell URIs appear in the current diagnose call's diagnostic map. Diagnose for cell A produces a map keyed by cell A's URI (and its imports); cell B is *not* in that map. So if cell B previously published an error, and the user edits cell A in a way that fixes cell B's compile (e.g., creates the source cell B was referencing), cell B's stale error stays in the Problems pane until the user edits cell B itself.

`translateCache.dependentsOf` was supposed to cover this via its "later cell in the same notebook" heuristic, but that heuristic compares cell URI fragments lexicographically — and cell fragments aren't ordered by notebook position, so the heuristic misses cells unpredictably.

**The fix:** when `onDidChangeContent` fires for a `vscode-notebook-cell:` URI, also call `debouncedDiagnoseDocument` on every other cell of the same notebook. `debouncedDiagnoseDocument` coalesces duplicates per-URI within its 300ms window so the cost stays bounded.

**Cycle-safety:** the fan-out lives only in `onDidChangeContent`. The sibling re-diagnose calls go through `debouncedDiagnoseDocument` directly; they don't re-enter the change handler. So one edit triggers one round of sibling re-diagnoses, not an infinite loop.

## Notes

- Bounded cost: the brute-force fan-out is N siblings per edit. Real notebooks have small N (typically <20 cells). Each re-diagnose hits the translate cache and short-circuits if the dependency keys are unchanged, so stale-but-still-valid cells don't re-translate.