### PR TITLE
Restore @malloydata/db-duckdb as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@duckdb/node-api": "^1.5.0-r.1",
         "@malloydata/db-bigquery": "0.0.390",
+        "@malloydata/db-duckdb": "0.0.390",
         "@malloydata/db-mysql": "0.0.390",
         "@malloydata/db-postgres": "0.0.390",
         "@malloydata/db-publisher": "0.0.390",

--- a/package.json
+++ b/package.json
@@ -560,6 +560,7 @@
   "dependencies": {
     "@duckdb/node-api": "^1.5.0-r.1",
     "@malloydata/db-bigquery": "0.0.390",
+    "@malloydata/db-duckdb": "0.0.390",
     "@malloydata/db-mysql": "0.0.390",
     "@malloydata/db-postgres": "0.0.390",
     "@malloydata/db-publisher": "0.0.390",


### PR DESCRIPTION
## Summary

PR #777 (Bump 0.0.388 → 0.0.390) accidentally dropped `@malloydata/db-duckdb` from `package.json`. The package is still installed via the transitive dep through `@malloydata/malloy-connections`, so the extension keeps working — but `db-duckdb` is **directly imported** by `src/server/connections/browser/connection_factory.ts` and **named** by `scripts/third_party_licenses.ts`, so we should declare it.

This adds the line back at the same version (`0.0.390`).

## Diff scope

Two lines, one in `package.json` and one in `package-lock.json`:

```
+    "@malloydata/db-duckdb": "0.0.390",
```

## How PR #777 dropped it

Most likely a side effect of `npm link` / `npm unlink` dancing against `db-duckdb` during the same session #777 was authored in (which was investigating the lock-release work). Verified independently after the fact: starting from a clean post-#776 state (`db-duckdb` still present at 0.0.388), running `npm run malloy-update` correctly preserves and bumps `db-duckdb` to 0.0.390 — i.e., the script and the install command are fine. The drop was a one-time artifact of the dirty intermediate state at the time #777 was branched.

The line had been present continuously in `package.json` since the file was created in November 2022 — 251 prior commits touched it (all version bumps), zero removed it before #777. So this restores 3.5 years of invariant.

## Why it matters even though things work today

- If `malloy-connections` ever drops its transitive on `db-duckdb`, the build breaks suddenly with no version warning.
- `npm run malloy-update` was silently skipping `db-duckdb` on every future run because the script reads from `package.json.dependencies`. Future bumps would have left `db-duckdb` drifting behind the others.

After this PR, future `malloy-update` runs include `db-duckdb` (verified locally — script output now lists `@malloydata/db-duckdb@latest`).

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json`
- [x] `npm run lint`
- [x] `npx jest --no-cache` (145/145)
- [x] `npm run build`
- [x] `npm run malloy-update` (from a clean state) preserves and bumps `db-duckdb` correctly