### PR TITLE
Clear progress spinner on query Error

### DIFF
--- a/src/extension/webviews/query_page/QueryPage.tsx
+++ b/src/extension/webviews/query_page/QueryPage.tsx
@@ -157,6 +157,7 @@ export function QueryPage({vscode}: QueryPageProps) {
           break;
         case QueryRunStatus.Error:
           setError(message.error);
+          setProgressMessage('');
           break;
         case QueryRunStatus.Compiled:
           if (message.showSQLOnly) {


### PR DESCRIPTION
## Summary
- The `Error` case in `QueryPage`'s message handler set the error string but never cleared `progressMessage`. Every other terminal status (`Done`, `Schema`, `EstimatedCost`, SQL-only `Compiled`) clears it; `Error` was the outlier.
- For a query with `given:` declarations, the worker sequence is `Compiling` → `Givens` → `Error` whenever the run blows up after the givens are discovered (e.g. a missing or wrong-typed given). With `progressMessage` stuck on `'Compiling'`, the render guard kept `<LabeledSpinner>` mounted forever, hiding both the error banner and the GIVENS tab that the existing `useEffect` was designed to auto-select.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json`
- [x] In the extension debugger, run a query with a wrong-typed given and confirm the GIVENS tab auto-pops with the error banner above the editor instead of an endless "Compiling" spinner.