### PR TITLE
Move GitHub Actions off deprecated Node 20

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -21,6 +21,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24.x'
+          # This repo uses npm; the packageManager field declares yarn, which
+          # v5's default cache auto-detects and then fails on (no yarn.lock).
+          package-manager-cache: false
       - name: Publish
         run: |
           set -euxo pipefail

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -14,11 +14,11 @@ jobs:
       - test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
       - name: Publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,11 +11,11 @@ jobs:
       - test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
       - name: Publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24.x'
+          # This repo uses npm; the packageManager field declares yarn, which
+          # v5's default cache auto-detects and then fails on (no yarn.lock).
+          package-manager-cache: false
       - name: Publish
         run: |
           set -euxo pipefail

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: 'true'
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '24.x'
       - name: Install and test
@@ -30,8 +30,11 @@ jobs:
           echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> "$GITHUB_ENV"
           dbus-daemon --session --address=$DBUS_SESSION_BUS_ADDRESS --nofork --nopidfile --syslog-only &
       - name: Run integration test
-        uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
-        with:
-          run: npm run integration
+        # Replaces coactions/setup-xvfb, which has no Node 24 release. That
+        # action just apt-installs xvfb and wraps the command in xvfb-run.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb x11-xserver-utils
+          xvfb-run --auto-servernum npm run integration
     env:
       CI: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,9 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: '24.x'
+          # This repo uses npm; the packageManager field declares yarn, which
+          # v5's default cache auto-detects and then fails on (no yarn.lock).
+          package-manager-cache: false
       - name: Install and test
         run: |
           npm ci --loglevel error


### PR DESCRIPTION
GitHub is forcing Node 20 JS actions to Node 24 on June 16th and removing Node 20 from runners in September. This clears the deprecation warnings across all three workflows.

- `actions/checkout@v4` → `@v5` and `actions/setup-node@v4` → `@v5` (their first Node 24 major) in `test`, `release`, and `prerelease`.
- `coactions/setup-xvfb` had no Node 24 release — its newest commit and tags still run on node16/node20 — so there was nothing to bump to. It only apt-installs xvfb and wraps the command in `xvfb-run`, so I inlined that as a plain shell step. It's no longer a JS action, so it can't be deprecated again.