### PR TITLE
ci: put release channel in the publish summary title

### DIFF
--- a/scripts/publish-extensions.ts
+++ b/scripts/publish-extensions.ts
@@ -42,10 +42,9 @@ function writePublishSummary(
   if (!summaryFile || results.length === 0) return;
 
   const lines = [
-    '## 🛍️ VS Code Extension Publish',
+    `## 🛍️ VS Code ${preRelease ? 'Pre-Release' : 'Release'} Extension Publish`,
     '',
     `- **Version**: \`${versionCode}\``,
-    `- **Channel**: ${preRelease ? 'pre-release' : 'release'}`,
     `- **VS Code Marketplace**: [malloydata.malloy-vscode](${MARKETPLACE_URL})`,
     `- **Open VSX**: [malloydata.malloy-vscode](${OPEN_VSX_URL})`,
     '',


### PR DESCRIPTION
Follow-up to #806. The publish summary used a fixed title (`🛍️ VS Code Extension Publish`) with the channel tucked into a `Channel:` bullet. Move the channel into the heading so the report reads at a glance:

- release → **🛍️ VS Code Release Extension Publish**
- pre-release → **🛍️ VS Code Pre-Release Extension Publish**

The separate `Channel` bullet is now redundant, so it's dropped. Version, store links, and the per-target table are unchanged.